### PR TITLE
Overhaul: λ-space pipeline, frame QA, unified make_matrix_lambda()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,19 @@ reports/
 *.fits
 data/
 .ipynb_checkpoints/
+.venv/
+__pycache__/
+.ipynb_checkpoints/
+
+data/
+outputs/
+*.fits
+*.fits.gz
+
+mvt\ frozen\ 250901/
+*.patch
+*.diff
+
+.DS_Store
+.vscode/
+.idea/

--- a/configs/dryrun_naid.yaml
+++ b/configs/dryrun_naid.yaml
@@ -40,3 +40,8 @@ figures:
 
 tables:
   table71_csv: table71.csv
+  
+debug:
+  enable: true
+  n_window_examples: 4
+  off_line_kms: [-120, -80]   # off-line band to probe baseline

--- a/configs/espre_2021-08-11_naid.yaml
+++ b/configs/espre_2021-08-11_naid.yaml
@@ -1,0 +1,67 @@
+night_dir: data/raw/ESPRE_2021-08-11
+outputs_dir: outputs/espre_2021-08-11
+
+target_line: NaID2
+
+# Is the incoming wavelength grid already corrected to the barycenter?
+input_frame: barycentric   # {native | barycentric}
+
+ephemeris:
+  T0_bjdtdb: 2456999.409715
+  period_days: 2.218575
+  impact_b: 0.66
+  k_rprs: 0.157
+  a_over_rs: 8.86
+  inc_deg: 85.7
+  Kp_kms: 154.0
+
+contacts:
+  T1: -0.016
+  T2: -0.010
+  T3:  0.010
+  T4:  0.016
+
+lines:
+  NaID2:   {center_A: 5891.583, half_width_A: 1.5}   # Na D2 (VAC)
+  NaID1:   {center_A: 5895.924, half_width_A: 1.5}   # Na D1 (AIR)
+  LiI6707: {center_A: 6707.0, half_width_A: 1.5}   # Li I 670.8 nm (AIR)
+  
+fit:
+  init_sigma_A: 0.157       # ~8 km/s at Na D2
+  window_kms: 15.0
+
+null_tests:
+  control_offset_A: 2.0
+
+residuals:
+  flatten_planet_sidebands: true
+  subtract_additive_trend: true       # NEW → enables step A
+  sideband_gap_kms: 70.0    # widen if you still see slope in residual wings
+
+figures:
+  colormap_Npix: 401
+  colormap_stellar_flux_png:  colormap_stellar_flux.png
+  colormap_stellar_resid_png: colormap_stellar_resid.png
+  colormap_planet_lambda_png: colormap_planet_lambda.png
+  stack_png:  stack.png
+  nulls_png:  nulls.png
+  inject_png: inject.png
+  phase_coverage_png: phase_coverage.png
+  colormap_percentile: 99.5      # robust autoscale
+  colormap_symmetric: true       # center at zero for residuals
+  colormap_vlim_resid: auto      # or [-0.02, 0.02]
+  colormap_vlim_flux:  auto      # flux can stay wider or 'auto'
+  colormap_cmap_resid: RdBu_r    # diverging is better for residuals centered at 0
+  
+tables:
+  table71_csv: table_71.csv
+
+debug:
+  enable: true
+  off_line_kms: [-120.0, -80.0]
+
+# (Optional: keep if/when you re-enable injection step)
+injection:
+  depths: [0.0005, 0.0010, 0.0015, 0.0020, 0.0025, 0.0030]
+  bootstrap_n: 800
+  rng_seed: 42

--- a/mvt/frameguess.py
+++ b/mvt/frameguess.py
@@ -1,0 +1,215 @@
+# mvt/frameguess.py
+from __future__ import annotations
+import sys
+import argparse
+import numpy as np
+
+C_KMS = 299_792.458
+
+def _mad(x: np.ndarray) -> float:
+    """Median Absolute Deviation → robust sigma (≈ std) via 1.4826 * MAD."""
+    x = np.asarray(x, float)
+    med = np.nanmedian(x)
+    return 1.4826 * np.nanmedian(np.abs(x - med))
+
+def _nan_corr(x: np.ndarray, y: np.ndarray) -> float:
+    """Robust correlation with NaN guarding; returns np.nan if undefined."""
+    m = np.isfinite(x) & np.isfinite(y)
+    if np.count_nonzero(m) < 5:
+        return np.nan
+    x = x[m]; y = y[m]
+    sx = np.nanstd(x); sy = np.nanstd(y)
+    if not np.isfinite(sx) or not np.isfinite(sy) or sx == 0 or sy == 0:
+        return np.nan
+    return float(np.corrcoef(x, y)[0, 1])
+
+def _read_framecheck(csv_path: str):
+    """Read the CSV produced by run_frame_qa()."""
+    data = np.genfromtxt(csv_path, delimiter=",", names=True, dtype=None, encoding=None)
+    # Required columns for verdict:
+    try:
+        v0 = np.asarray(data["v0_stellar_kms"], float)
+        berv = np.asarray(data["berv_kms"], float)
+    except Exception as e:
+        raise KeyError(
+            f"framecheck.csv missing required columns: 'v0_stellar_kms' and/or 'berv_kms' "
+            f"(error: {e}). Did run_frame_qa() run and write the expected header?"
+        )
+    # Optional columns:
+    in_tr = None
+    if "in_transit" in data.dtype.names:
+        in_tr = np.asarray(data["in_transit"], int) == 1
+    return v0, berv, in_tr
+
+def _verdict(v0: np.ndarray, berv: np.ndarray, *, thr_ratio=0.30, corr_thr=0.50):
+    """
+    One-line verdict: 'barycentric' vs 'native' based on scatter & correlation.
+
+    Heuristic:
+      - If robust scatter of v0* is comparable to BERV (ratio > thr_ratio)
+        AND |corr(v0*, BERV)| >= corr_thr → looks **native** (BERV not removed).
+      - else → looks **barycentric** (typical ESPRESSO DRS wavelength grid).
+    """
+    m = np.isfinite(v0) & np.isfinite(berv)
+    v0 = v0[m]; berv = berv[m]
+    if v0.size < 5:
+        return ("unknown", "not enough finite rows for a verdict", np.nan, np.nan, np.nan, np.nan)
+
+    s_v0   = _mad(v0)     # km/s
+    s_berv = _mad(berv)   # km/s
+    corr   = _nan_corr(v0, berv)
+    ratio  = (s_v0 / s_berv) if s_berv > 0 else np.inf
+    medabs = float(np.nanmedian(np.abs(v0)))
+
+    if np.isfinite(corr) and (ratio > thr_ratio) and (abs(corr) >= corr_thr):
+        guess  = "native"
+        reason = f"v0_stellar scatter {s_v0:.2f} ~ BERV scatter {s_berv:.2f} (corr={corr:.2f})"
+    else:
+        guess  = "barycentric"
+        reason = f"v0_stellar scatter {s_v0:.2f} << BERV scatter {s_berv:.2f} (corr={corr:.2f})"
+
+    return (guess, reason, s_v0, s_berv, corr, medabs)
+
+def _impact(v0: np.ndarray,
+            berv: np.ndarray,
+            *,
+            sigma_kms: float,
+            center_A: float,
+            use_mask: np.ndarray | None = None):
+    """
+    Impact metrics (smear + wavelength displacement):
+      - R_frame = |rho| * MAD(BERV) / sigma_line
+      - Predicted depth attenuation = 1/sqrt(1 + R^2)
+      - Predicted width increase = (sqrt(1 + R^2) - 1)
+      - Δλ_mismatch_A ≈ λ0 * (|rho|*MAD(BERV))/c   (smear scale in Å)
+      - Δλ_bias_med_A ≈ λ0 * (|median(v0)|)/c      (constant bias in Å)
+    """
+    if use_mask is None:
+        m = np.isfinite(v0) & np.isfinite(berv)
+    else:
+        m = np.isfinite(v0) & np.isfinite(berv) & np.asarray(use_mask, bool)
+
+    v0 = v0[m]; berv = berv[m]
+    if v0.size < 5:
+        return None
+
+    s_berv = _mad(berv)
+    rho    = _nan_corr(v0, berv)
+    v0_med = float(np.nanmedian(v0))
+
+    sigma_line = float(sigma_kms)
+    fwhm_kms   = 2.355 * sigma_line
+    fwhm_A     = center_A * (fwhm_kms / C_KMS)
+
+    sigma_mismatch_kms = (abs(rho) * s_berv) if np.isfinite(rho) else np.nan
+    R = sigma_mismatch_kms / sigma_line if (np.isfinite(sigma_mismatch_kms) and sigma_line > 0) else np.nan
+    dlam_mismatch_A = center_A * (sigma_mismatch_kms / C_KMS) if np.isfinite(sigma_mismatch_kms) else np.nan
+
+    dlam_bias_med_A = center_A * (abs(v0_med) / C_KMS) if np.isfinite(v0_med) else np.nan
+
+    depth_factor = 1.0 / np.sqrt(1.0 + R*R) if np.isfinite(R) else np.nan
+    loss_pct = (1.0 - depth_factor) * 100.0 if np.isfinite(depth_factor) else np.nan
+    width_increase_pct = (np.sqrt(1.0 + R*R) - 1.0) * 100.0 if np.isfinite(R) else np.nan
+
+    return dict(
+        rho=rho,
+        mad_berv=s_berv,
+        v0_med=v0_med,
+        R_frame=R,
+        depth_factor=depth_factor,
+        depth_loss_pct=loss_pct,
+        width_increase_pct=width_increase_pct,
+        smear_kms=sigma_mismatch_kms,
+        smear_A=dlam_mismatch_A,
+        bias_A=dlam_bias_med_A,
+        fwhm_kms=fwhm_kms,
+        fwhm_A=fwhm_A,
+        bias_vs_fwhm=(abs(v0_med)/fwhm_kms) if fwhm_kms > 0 else np.nan,
+        smear_vs_fwhm=(sigma_mismatch_kms/fwhm_kms) if fwhm_kms > 0 else np.nan
+    )
+
+def verdict_from_framecheck(csv_path: str,
+                            thr_ratio: float = 0.30,
+                            corr_thr: float = 0.50,
+                            sigma_kms: float | None = None,
+                            center_A: float | None = None,
+                            use_all_rows: bool = False) -> None:
+    """
+    Print consolidated assessment.
+      - Always prints one-line verdict.
+      - If sigma_kms & center_A are provided → prints impact metrics too.
+    """
+    v0, berv, in_tr = _read_framecheck(csv_path)
+
+    guess, reason, s_v0, s_berv, corr, medabs = _verdict(
+        v0, berv, thr_ratio=thr_ratio, corr_thr=corr_thr
+    )
+
+    # One-line verdict (keeps backward compatibility)
+    print(
+        f"Input wavelength frame looks **{guess}** — {reason}; "
+        f"median|v0_stellar|={medabs:.2f} km/s — file: {csv_path}"
+    )
+
+    # Impact block (optional)
+    if sigma_kms is not None and center_A is not None:
+        mask = None if (use_all_rows or in_tr is None) else (in_tr == 1)
+        impact = _impact(v0, berv, sigma_kms=float(sigma_kms), center_A=float(center_A), use_mask=mask)
+        if impact is None:
+            print("Impact: not enough finite rows to estimate metrics.")
+            return
+
+        scope = "ALL exposures" if (use_all_rows or in_tr is None) else "in-transit only"
+        print(
+            "\nImpact assessment "
+            f"(σ_line={float(sigma_kms):.3f} km/s, λ0={float(center_A):.3f} Å, {scope}):"
+        )
+        print(
+            "  Smear driver: R_frame = |ρ|·MAD(BERV)/σ_line = "
+            f"{impact['R_frame']:.3f}  (ρ={impact['rho']:.3f}, MAD(BERV)={impact['mad_berv']:.3f} km/s)"
+        )
+        print(
+            f"  Predicted depth attenuation = {impact['depth_factor']:.3f}  "
+            f"(loss ≈ {impact['depth_loss_pct']:.1f}%)"
+        )
+        print(
+            f"  Predicted width increase    ≈ {impact['width_increase_pct']:.1f}%"
+        )
+        print(
+            f"  Velocity smear scale ≈ {impact['smear_kms']:.3f} km/s "
+            f"({impact['smear_vs_fwhm']:.3f} × FWHM={impact['fwhm_kms']:.3f} km/s)"
+        )
+        print(
+            f"  Wavelength smear scale ≈ {impact['smear_A']:.5f} Å;   "
+            f"bias (median) ≈ {impact['bias_A']:.5f} Å "
+            f"({impact['bias_vs_fwhm']:.3f} × FWHM={impact['fwhm_A']:.4f} Å)"
+        )
+    else:
+        # gentle hint to enable impact block
+        print("(Pass --sigma-kms and --center-A to also get smearing and wavelength-displacement impact.)")
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(
+        description="Consolidated frame verdict + impact from framecheck.csv"
+    )
+    ap.add_argument("csv", help="outputs/.../framecheck.csv")
+    ap.add_argument("--thr-ratio", type=float, default=0.30,
+                    help="threshold on s(v0*)/s(BERV) for 'native' (default 0.30)")
+    ap.add_argument("--corr-thr", type=float, default=0.50,
+                    help="|corr(v0*, BERV)| threshold for 'native' (default 0.50)")
+    ap.add_argument("--sigma-kms", type=float, default=None,
+                    help="intrinsic line sigma in km/s (enables impact block)")
+    ap.add_argument("--center-A", type=float, default=None,
+                    help="line center wavelength in Å (enables impact block)")
+    ap.add_argument("--all", action="store_true",
+                    help="use ALL rows for impact (default: in-transit only when available)")
+    args = ap.parse_args()
+
+    verdict_from_framecheck(
+        args.csv,
+        thr_ratio=args.thr_ratio,
+        corr_thr=args.corr_thr,
+        sigma_kms=args.sigma_kms,
+        center_A=args.center_A,
+        use_all_rows=args.all,
+    )

--- a/mvt/frameqa.py
+++ b/mvt/frameqa.py
@@ -1,0 +1,102 @@
+# mvt/frameqa.py
+from __future__ import annotations
+import os
+import numpy as np
+from typing import Tuple
+from .matrix import make_matrix_lambda
+from .fitlines import fit_gaussian_velocity
+
+C_KMS = 299_792.458
+
+def _vgrid_from_lambda(lam_grid_A: np.ndarray, center_A: float) -> np.ndarray:
+    lam_grid_A = np.asarray(lam_grid_A, float)
+    return C_KMS * (lam_grid_A - float(center_A)) / float(center_A)
+
+def _fit_per_row(lam_grid_A: np.ndarray, R: np.ndarray,
+                 center_A: float, window_kms: float, init_sigma_kms: float
+                 ) -> Tuple[np.ndarray, np.ndarray]:
+    vgrid = _vgrid_from_lambda(lam_grid_A, center_A)
+    mwin = (vgrid >= -window_kms) & (vgrid <= +window_kms)
+    v0_kms = np.full(R.shape[0], np.nan, float)
+    depth  = np.full(R.shape[0], np.nan, float)
+    for i in range(R.shape[0]):
+        y = R[i, mwin]; x = vgrid[mwin]
+        if np.isfinite(y).sum() >= 8:
+            fit = fit_gaussian_velocity(x, y, init_sigma_kms, center_A=center_A)
+            v0_kms[i] = float(getattr(fit, "v0_kms", np.nan))
+            depth[i]  = float(getattr(fit, "depth",   np.nan))
+    return v0_kms, depth
+
+def _baseline_band_stats(vgrid: np.ndarray, R: np.ndarray, band_kms=(-120.0, -80.0)):
+    j = (vgrid >= band_kms[0]) & (vgrid <= band_kms[1])
+    med = np.nanmedian(R[:, j], axis=1)
+    mad = 1.4826 * np.nanmedian(np.abs(R[:, j] - med[:, None]), axis=1)
+    return med, mad
+
+def run_frame_qa(
+    wavelength_A, flux,
+    lam_sr, R_sr,
+    lam_pr, R_pr,
+    bjd_tdb_arr, phases, in_transit,
+    berv_kms, rv_star_kms,
+    center_A, half_A,
+    cfg, fig_dir, tab_dir,
+    input_frame: str = "native",        # ← NEW
+) -> None:
+    # Build barycentric residuals on the SAME Npix as the others
+    Npix = int(cfg.get("figures", {}).get("colormap_Npix", 401))
+    lam_by, R_by, _ = make_matrix_lambda(
+        wavelength_A, flux,
+        frame="barycentric", quantity="residuals",
+        center_A=center_A, half_A=half_A,
+        bervs=berv_kms, rv_stars=rv_star_kms,
+        in_transit=in_transit,
+        Npix=Npix,
+        sideband_flatten=True,
+        subtract_additive_trend=cfg.get("residuals", {}).get("subtract_additive_trend", True),
+        trend_gap_kms=cfg.get("residuals", {}).get("sideband_gap_kms", 40.0),
+        input_frame=input_frame,        # ← respect how ESPRESSO files are encoded
+    )
+
+    init_sigma_A   = float(cfg["fit"]["init_sigma_A"])
+    init_sigma_kms = C_KMS * init_sigma_A / float(center_A)
+    fit_window_kms = float(cfg["fit"].get("window_kms", 15.0))
+
+    # Per-row centroids & depths
+    v0_stellar, d_stellar = _fit_per_row(lam_sr, R_sr, center_A, fit_window_kms, init_sigma_kms)
+    v0_bary,   d_bary    = _fit_per_row(lam_by, R_by, center_A, fit_window_kms, init_sigma_kms)
+    v0_planet, d_planet  = _fit_per_row(lam_pr, R_pr, center_A, fit_window_kms, init_sigma_kms)
+
+    # Baseline QC on planet-rest matrix
+    vgrid_pr = _vgrid_from_lambda(lam_pr, center_A)
+    band_kms = tuple(cfg.get("debug", {}).get("off_line_kms", [-120.0, -80.0]))
+    base_med, base_mad = _baseline_band_stats(vgrid_pr, R_pr, band_kms=band_kms)
+
+    finite_frac = np.isfinite(R_pr).mean(axis=1)
+
+    # CSV
+    os.makedirs(tab_dir, exist_ok=True)
+    qa_csv = os.path.join(tab_dir, "framecheck.csv")
+    with open(qa_csv, "w") as f:
+        f.write("idx,bjd,phase,in_transit,berv_kms,rv_star_kms,"
+                "v0_stellar_kms,v0_bary_kms,v0_planet_kms,"
+                "depth_stellar_pct,depth_bary_pct,depth_planet_pct,"
+                "baseline_offline,baseline_mad_offline,finite_frac\n")
+        for i in range(len(bjd_tdb_arr)):
+            f.write(
+                f"{i},{bjd_tdb_arr[i]:.6f},{phases[i]:+.6f},{int(in_transit[i])},"
+                f"{(berv_kms[i] if berv_kms is not None else np.nan):.3f},"
+                f"{(rv_star_kms[i] if rv_star_kms is not None else np.nan):.3f},"
+                f"{v0_stellar[i]:.3f},{v0_bary[i]:.3f},{v0_planet[i]:.3f},"
+                f"{(100.0*d_stellar[i] if np.isfinite(d_stellar[i]) else np.nan):.3f},"
+                f"{(100.0*d_bary[i]    if np.isfinite(d_bary[i])    else np.nan):.3f},"
+                f"{(100.0*d_planet[i]  if np.isfinite(d_planet[i])  else np.nan):.3f},"
+                f"{base_med[i]:.4e},{base_mad[i]:.4e},{finite_frac[i]:.3f}\n"
+            )
+
+    it = np.asarray(in_transit, bool)
+    msg = (f"Frame QA: median|v0_stellar|={np.nanmedian(np.abs(v0_stellar)):.2f} km/s; "
+           f"median|v0_bary|={np.nanmedian(np.abs(v0_bary)):.2f} km/s; "
+           f"median_IT|v0_planet|={np.nanmedian(np.abs(v0_planet[it])):.2f} km/s; "
+           f"median_IT depth={np.nanmedian(100.0*d_planet[it]):.3f}%  → wrote {qa_csv}")
+    print(msg)

--- a/mvt/matrix.py
+++ b/mvt/matrix.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+import numpy as np
+from typing import List, Tuple, Optional
+from .rv import to_stellar_rest
+from .timephase import phases_from_bjd
+from .residuals import _normalize_by_sidebands_local
+from mvt.rv import planet_rv_kms, to_stellar_rest
+
+
+C_KMS = 299_792.458
+
+
+def _shift_to_frame(
+    lam_native: np.ndarray,
+    frame: str,
+    *,
+    rv_star_kms: float | None = None,
+    berv_kms: float | None = None,
+    v_planet_kms: float | None = None,
+    center_A: float | None = None,
+    input_frame: str = "native",   # NEW: tells us what lam_native already is
+    relativistic: bool = False,    # optional: exact Doppler if you want
+) -> np.ndarray:
+    """
+    Return wavelengths shifted into the requested frame.
+
+    Frames
+    ------
+    - "native"      : return input as-is
+    - "barycentric" : remove BERV only
+    - "stellar"     : remove BERV + stellar RV*
+    - "planet"      : start from STELLAR, then subtract planet RV (bring the
+                      planetary line to ~v=0 when plotted in velocity space)
+
+    Notes
+    -----
+    - `input_frame` declares what the *input* wavelengths already are. If you
+      pass input_frame="barycentric", BERV will not be removed again.
+    - For ESPRESSO S1D this is usually "native".
+    - For |v|≲150 km/s the classical formula is fine; set `relativistic=True`
+      if you want the exact factor.
+    """
+    lam = np.asarray(lam_native, float)
+
+    if frame == "native":
+        return lam
+
+    # choose Doppler factor
+    def _lam_shift(l, v_kms):
+        if v_kms is None or v_kms == 0.0:
+            return l
+        beta = (v_kms / C_KMS)
+        if not relativistic:
+            # classical: lambda' = lambda / (1 + v/c)
+            return l / (1.0 + beta)
+        # relativistic (radial): D = sqrt((1+beta)/(1-beta)); lambda' = lambda / D
+        D = np.sqrt((1.0 + beta) / (1.0 - beta))
+        return l / D
+
+    # Work out how much BERV is still present in the input
+    berv_eff = 0.0 if input_frame.lower() == "barycentric" else (berv_kms or 0.0)
+
+    if frame == "barycentric":
+        return _lam_shift(lam, berv_eff)
+
+    # Stellar rest = remove (BERV that remains in the input) + stellar RV
+    lam_sr = _lam_shift(lam, berv_eff + (rv_star_kms or 0.0))
+    if frame == "stellar":
+        return lam_sr
+
+    if frame == "planet":
+        # planet rest = stellar rest minus planet RV
+        return _lam_shift(lam_sr, (v_planet_kms or 0.0))
+
+    # Fallback: nothing
+    return lam
+
+def _regular_lambda_grid(center_A: float, half_A: float, Npix: int) -> np.ndarray:
+    return np.linspace(center_A - half_A, center_A + half_A, int(Npix), dtype=float)
+
+
+def _interp_to_grid(x, y, xgrid):
+    x = np.asarray(x, float); y = np.asarray(y, float)
+    if x.size < 2 or np.all(~np.isfinite(y)):
+        return np.full_like(xgrid, np.nan, dtype=float)
+    return np.interp(xgrid, x, y, left=np.nan, right=np.nan)
+
+def make_matrix_lambda(
+    waves, fluxes, *,
+    frame: str,                   # "stellar" | "planet" | "barycentric" | "native"
+    quantity: str,                # "flux" | "residuals"
+    center_A: float, half_A: float,
+    bervs=None, rv_stars=None,
+    bjds=None, phases=None, Kp_kms=None,
+    in_transit=None,
+    Npix: int = 401,
+    sideband_flatten: bool = False,
+    subtract_additive_trend: bool = True,
+    trend_gap_kms: float = 70.0,
+    input_frame: str = "native",
+):
+    """
+    Build a [N_exp, Npix] matrix on a *regular wavelength grid* in the requested
+    OUTPUT frame; return (lam_grid, M, v_plan) where:
+
+        lam_grid [Npix]      : wavelength grid (Å) in the chosen OUTPUT frame
+        M        [N_exp,Npix]: matrix of FLUX or RESIDUALS (dimensionless)
+        v_plan   [N_exp] | None: planet RV per exposure (km/s) if frame="planet"
+
+    ─────────────────────────────────────────────────────────────────────────────
+    HIGH-LEVEL FLOW (what happens, in which frame)
+    ─────────────────────────────────────────────────────────────────────────────
+    0) Convert each exposure to the *stellar rest* (this is the base working frame):
+         lam_stellar = _to_stellar_from_input(lam_native, input_frame, berv, rv_star)
+       Notes on `input_frame` semantics:
+         - "native":  lam_native still carries BOTH BERV and RV_* → remove both.
+         - "barycentric": lam_native already corrected for BERV → remove RV_* only.
+       (ESPRESSO S1D is commonly *barycentric*; use frameguess to confirm.)
+
+    1) Define a *stellar-rest* output grid lam_sr_grid covering [center_A±half_A]
+       with Npix points, and interpolate **flux** for each exposure onto this grid.
+       At this point we have F_sr [N_exp, Npix] — FLUX in stellar rest.
+
+    2) If `quantity == "flux"`, we can already return (lam_sr_grid, F_sr, v_plan).
+
+    3) For `quantity == "residuals"`:
+       3a) Identify OOT rows from `in_transit`. We *require* enough OOT coverage
+           per wavelength column; otherwise we TRIM columns with poor OOT support.
+           If very little survives, we AUTO-SHRINK the grid to the intersection
+           of OOT coverage and re-interpolate (this avoids division by near-zero).
+       3b) Build the OOT master spectrum in *stellar rest*:
+               oot_sr = median(F_sr[OOT], axis=0)
+       3c) Form per-row *ratios* and residuals:
+               ratio_sr = F_sr / oot_sr      (≈1 in continuum)
+               R_sr     = ratio_sr - 1.0
+
+       Optional cleanups (still in *stellar rest*):
+         • sideband_flatten=True  → multiplicative flattening:
+             normalize ratio_sr by sideband medians/slopes, then back to residuals
+         • subtract_additive_trend=True → additive (linear) detrend of residuals
+             fit resid ≈ a*v + b using |v| ≥ trend_gap_kms and subtract (a*v+b)
+
+       IMPORTANT: The OOT master and all cleaning are done **in stellar rest**.
+                  This avoids mixing frames while defining the continuum.
+
+    4) Map residuals to the requested OUTPUT frame:
+         - frame="stellar"     → return (lam_sr_grid, R_sr)
+         - frame="planet"      → return residuals sampled on a *planet-rest*
+                                 grid of the same λ coordinates:
+               For exposure i, with planet RV v_p[i], evaluate the STELLAR
+               residual at λ_src = λ_pr * (1 + v_p/c). This is equivalent to
+               shifting the *model grid* rather than resampling the data loop.
+         - frame="barycentric" → callers typically re-label; we return the same
+                                 stellar-grid residuals (λ grid is stellar).
+
+    Robustness choices:
+      • Columns must have at least ~30% of the OOT rows finite (min ≥2). If that
+        leaves too few columns, we shrink the grid to the OOT intersection and
+        retry with a ≥20% threshold. If still too few columns, we raise.
+      • All interpolations are NaN-safe; divisions use the trimmed, finite OOT
+        master to avoid blowing up on poorly covered columns.
+
+    Parameters not detailed above:
+      phases, Kp_kms  : needed only for frame="planet" (v_plan[i] = Kp*sin(2πφ_i))
+      trend_gap_kms   : velocity gap that defines sidebands for additive detrend
+    """
+
+    import numpy as np
+    C_KMS = 299_792.458
+
+    frame        = (frame or "stellar").lower()
+    quantity     = (quantity or "residuals").lower()
+    input_frame  = (input_frame or "native").lower()
+
+    waves  = list(waves);   fluxes = list(fluxes)
+    N = len(waves)
+    if rv_stars is None: rv_stars = [None] * N
+    if bervs    is None: bervs    = [None] * N
+
+    # Planet RV curve if we will output in the planet frame
+    v_plan = None
+    if frame == "planet":
+        if phases is None or Kp_kms is None:
+            raise ValueError("frame='planet' requires phases and Kp_kms.")
+        from .rv import planet_rv_kms
+        v_plan = planet_rv_kms(np.asarray(phases, float), float(Kp_kms))
+
+    # Simple wrapper: interpolate one exposure onto a target stellar grid
+    def _interp_row(lam_native, f_native, grid_stellar):
+        lam_native = np.asarray(lam_native, float)
+        f_native   = np.asarray(f_native, float)
+        return _interp_to_grid(lam_native, f_native, grid_stellar)
+
+    # ── [STEP 0] Convert each exposure to STELLAR rest & track coverage window
+    lam_stellar_rows, f_rows = [], []
+    win_min, win_max = [], []
+    for i in range(N):
+        lam_native = np.asarray(waves[i], float)
+        f_i        = np.asarray(fluxes[i], float)
+
+        # from input_frame → stellar rest:
+        #  - native → remove (BERV + RV_*)
+        #  - barycentric → remove RV_* only
+
+        lam_stellar = _to_stellar_from_input(
+            lam_native, input_frame,
+            berv_kms=(None if bervs    is None else bervs[i]),
+            rv_star_kms=(None if rv_stars is None else rv_stars[i]),
+        )
+        lam_stellar_rows.append(lam_stellar); f_rows.append(f_i)
+
+        # exposure-specific coverage within the requested window
+        m0 = (lam_stellar >= center_A - half_A) & (lam_stellar <= center_A + half_A)
+        if np.any(m0):
+            win_min.append(float(np.nanmin(lam_stellar[m0])))
+            win_max.append(float(np.nanmax(lam_stellar[m0])))
+        else:
+            win_min.append(np.nan); win_max.append(np.nan)
+
+    # ── [STEP 1] Build base stellar grid over the requested window
+    lam_sr_grid = _regular_lambda_grid(center_A, half_A, Npix)
+
+    # Interpolate flux to this grid (stellar rest)
+    F_sr = np.vstack([
+        _interp_row(
+            lam_stellar_rows[i][(lam_stellar_rows[i] >= lam_sr_grid.min()) &
+                                (lam_stellar_rows[i] <= lam_sr_grid.max())],
+            f_rows[i][(lam_stellar_rows[i] >= lam_sr_grid.min()) &
+                      (lam_stellar_rows[i] <= lam_sr_grid.max())],
+            lam_sr_grid
+        )
+        for i in range(N)
+    ])  # [N, Npix]
+
+    # If callers only want FLUX, we are done.
+    if quantity == "flux":
+        return lam_sr_grid, F_sr, v_plan
+
+    # ── [STEP 2] Residuals need OOT master (still in stellar rest)
+    if in_transit is None:
+        raise ValueError("Residuals require in_transit mask to define OOT.")
+    oot = ~np.asarray(in_transit, bool)
+    if not np.any(oot):
+        raise ValueError("No OOT exposures available.")
+
+    # A) Keep only columns with sufficient OOT coverage
+    oot_count_per_col = np.isfinite(F_sr[oot]).sum(axis=0)
+    min_oot = max(2, int(0.3 * oot.sum()))  # at least 30% of OOT rows (but ≥2)
+    good_col = oot_count_per_col >= min_oot
+
+    # If that leaves too few columns, shrink to the OOT intersection & retry
+    if good_col.sum() < max(10, int(0.2 * Npix)):
+        oot_idx = np.where(oot)[0]
+        mins = [win_min[i] for i in oot_idx if np.isfinite(win_min[i])]
+        maxs = [win_max[i] for i in oot_idx if np.isfinite(win_max[i])]
+        if len(mins) and len(maxs):
+            lamL = float(np.nanmax(mins))
+            lamR = float(np.nanmin(maxs))
+        else:
+            lamL, lamR = np.nan, np.nan
+
+        if not (np.isfinite(lamL) and np.isfinite(lamR) and lamR > lamL):
+            raise ValueError(
+                "No OOT overlap with requested window. "
+                "Check input_frame/BERV/RV* and line center/half_width."
+            )
+
+        lam_sr_grid = np.linspace(lamL, lamR, Npix, dtype=float)
+        F_sr = np.vstack([
+            _interp_row(
+                lam_stellar_rows[i][(lam_stellar_rows[i] >= lam_sr_grid.min()) &
+                                    (lam_stellar_rows[i] <= lam_sr_grid.max())],
+                f_rows[i][(lam_stellar_rows[i] >= lam_sr_grid.min()) &
+                          (lam_stellar_rows[i] <= lam_sr_grid.max())],
+                lam_sr_grid
+            ) for i in range(N)
+        ])
+        oot_count_per_col = np.isfinite(F_sr[oot]).sum(axis=0)
+        min_oot = max(1, int(0.2 * oot.sum()))
+        good_col = oot_count_per_col >= min_oot
+
+    if good_col.sum() < 5:
+        raise ValueError("Too few λ-columns with OOT coverage after trimming.")
+
+    # Apply the column mask (guarantees finite OOT master)
+    lam_sr_grid = lam_sr_grid[good_col]
+    F_sr        = F_sr[:, good_col]
+
+    # OOT master and residuals (stellar rest)
+    with np.errstate(invalid="ignore"):
+        oot_sr = np.nanmedian(F_sr[oot], axis=0)        # finite by construction on kept cols
+    with np.errstate(invalid="ignore", divide="ignore"):
+        ratio_sr = F_sr / oot_sr[None, :]
+    R_sr = ratio_sr - 1.0
+
+    # Optional multiplicative flatten → operate on ratio then back to residuals
+    if sideband_flatten:
+        for i in range(N):
+            rpos = ratio_sr[i]
+            if np.isfinite(rpos).sum() >= 5:
+                rpos2 = _normalize_by_sidebands_local(lam_sr_grid, rpos, center_A, half_A)
+                R_sr[i] = rpos2 - 1.0
+
+    # Optional additive linear detrend in sidebands |v| ≥ trend_gap_kms
+    if subtract_additive_trend:
+        v_sr = C_KMS * (lam_sr_grid - center_A) / center_A
+        sb = np.isfinite(v_sr) & (np.abs(v_sr) >= float(trend_gap_kms))
+        x  = v_sr[sb]
+        if x.size >= 2:
+            for i in range(N):
+                y = R_sr[i, sb]
+                if np.isfinite(y).sum() >= 5:
+                    a, b = np.polyfit(x, y, 1)
+                    R_sr[i] = R_sr[i] - (a * v_sr + b)
+
+    # ── [STEP 3] Map to the requested OUTPUT frame
+    if frame == "stellar":
+        return lam_sr_grid, R_sr, v_plan
+
+    if frame == "planet":
+        # Keep the same λ grid coordinates but *sample* the stellar residual at
+        # a Doppler-shifted λ for each exposure (equivalent to de-shifting rows).
+        lam_pr_grid = lam_sr_grid.copy()
+        R_pr = np.empty_like(R_sr)
+        for i in range(N):
+            vp = 0.0 if v_plan is None else float(v_plan[i])
+#            lam_src = lam_pr_grid * (1.0 + vp / C_KMS)  # sample the stellar residual at shifted λ
+            lam_src = lam_pr_grid * (1.0 - vp / C_KMS)  # sample the stellar residual at shifted λ
+            R_pr[i] = np.interp(lam_src, lam_sr_grid, R_sr[i], left=np.nan, right=np.nan)
+        return lam_pr_grid, R_pr, v_plan
+
+    if frame == "barycentric":
+        # Residuals were constructed in stellar rest; most callers just re-label.
+        return lam_sr_grid, R_sr, v_plan
+    
+# --- Additive trend removal on sidebands (AFTER residuals) ---
+def _subtract_additive_trend_in_sidebands(lam_grid, resid_row, center_A, gap_kms=40.0):
+    """
+    Fit resid ≈ a*v + b in sidebands (|v| >= gap_kms) and subtract it.
+    Inputs
+      lam_grid : [Npix] λ-grid (already in the chosen frame)
+      resid_row: [Npix] residuals (F/F_OOT - 1) for ONE exposure
+      center_A : line center [Å]
+      gap_kms  : half-gap defining sidebands [km/s]
+    """
+    C_KMS = 299_792.458
+    lam_grid = np.asarray(lam_grid, float)
+    r = np.asarray(resid_row, float)
+
+    v_loc = C_KMS * (lam_grid - float(center_A)) / float(center_A)
+    sb = np.isfinite(r) & (np.abs(v_loc) >= float(gap_kms))
+    if np.count_nonzero(sb) >= 5:
+        a, b = np.polyfit(v_loc[sb], r[sb], 1)
+        return r - (a * v_loc + b)
+    return r
+
+
+def _to_stellar_from_input(lam_native, input_frame, *, berv_kms=None, rv_star_kms=None):
+    lam = np.asarray(lam_native, float)
+    f = (input_frame or "native").lower()
+    if f in ("stellar", "sr"):
+        return lam
+    if f in ("barycentric", "bary", "bc"):
+        return to_stellar_rest(lam, rv_star_kms=rv_star_kms or 0.0, berv_kms=0.0)
+    if f in ("native", "obs", "topocentric"):
+        return to_stellar_rest(lam, rv_star_kms=rv_star_kms or 0.0, berv_kms=berv_kms or 0.0)
+    raise ValueError(f"Unknown input_frame='{input_frame}'")

--- a/mvt/nulls.py
+++ b/mvt/nulls.py
@@ -11,6 +11,9 @@ class StackResult:
     p84: np.ndarray
 
 def _percentile_stack(v_grid: np.ndarray, profiles: List[np.ndarray]) -> StackResult:
+    if not profiles:
+        nan = np.full_like(v_grid, np.nan, dtype=float)
+        return StackResult(v_grid=v_grid, median=nan, p16=nan.copy(), p84=nan.copy())
     arr = np.vstack(profiles)
     med = np.nanmedian(arr, axis=0)
     p16 = np.nanpercentile(arr, 16, axis=0)
@@ -18,6 +21,8 @@ def _percentile_stack(v_grid: np.ndarray, profiles: List[np.ndarray]) -> StackRe
     return StackResult(v_grid=v_grid, median=med, p16=p16, p84=p84)
 
 def _interp_shift(v_grid: np.ndarray, prof: np.ndarray, dv: float) -> np.ndarray:
+    if prof is None or len(prof) == 0:
+        return np.full_like(v_grid, np.nan, dtype=float)
     return np.interp(v_grid, v_grid - dv, prof, left=np.nan, right=np.nan)
 
 def null_oot_only(v_grid: np.ndarray, resid_v: List[np.ndarray], in_transit: np.ndarray) -> StackResult:

--- a/mvt/plots.py
+++ b/mvt/plots.py
@@ -1,7 +1,95 @@
 from __future__ import annotations
 import matplotlib.pyplot as plt
 import numpy as np
-from typing import List
+from typing import List, Tuple, Optional
+
+from mvt.rv import to_stellar_rest
+
+from matplotlib.colors import TwoSlopeNorm
+
+
+C_KMS = 299_792.458
+
+
+
+def _robust_limits(arr2d, lo=1, hi=99):
+    """Percentile-based vmin/vmax for imshow."""
+    a = np.asarray(arr2d, float)
+    a = a[np.isfinite(a)]
+    if a.size == 0:
+        return -1, +1
+    return np.percentile(a, lo), np.percentile(a, hi)
+
+
+def plot_phase_coverage(phases, in_transit, contacts, out_png, title="Phase coverage"):
+    phases = np.asarray(phases, float)
+    it = np.asarray(in_transit, bool)
+
+    fig = plt.figure(figsize=(8, 3))
+    ax = fig.add_subplot(111)
+
+    # Shade transit window
+    ax.axvspan(contacts.T1, contacts.T4, color="tab:blue", alpha=0.08, label="Transit")
+    # Vertical lines at contacts
+    for x, ls in [(contacts.T1, "--"), (contacts.T2, ":"), (contacts.T3, ":"), (contacts.T4, "--")]:
+        ax.axvline(x, color="tab:blue", ls=ls, lw=1)
+
+    ax.scatter(phases[~it], np.zeros(np.sum(~it)), s=18, color="0.4", label="OOT", zorder=3)
+    ax.scatter(phases[it],   np.zeros(np.sum(it)),   s=30, color="tab:red", label="IT",  zorder=4)
+
+    ax.set_xlabel("Orbital phase")
+    ax.set_yticks([])
+    ax.set_title(title)
+    ax.legend(loc="upper right", frameon=False)
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=160)
+    plt.close(fig)
+
+def plot_window_examples(waves, fluxes, center_A, half_A, idxs, out_png: str, title="Raw window & sidebands"):
+    import matplotlib.pyplot as plt
+    fig, axs = plt.subplots(2, 2, figsize=(8, 6))
+    axs = axs.ravel()
+    for ax, i in zip(axs, idxs):
+        w = np.asarray(waves[i]); f = np.asarray(fluxes[i])
+        m = (w >= center_A - half_A) & (w <= center_A + half_A)
+        ax.plot(w[m], f[m], lw=1.0)
+        ax.axvline(center_A, ls="--", color="k", alpha=0.4)
+        ax.set_title(f"exp #{i}")
+    for ax in axs[-2:]: ax.set_xlabel("Wavelength [Å]")
+    for ax in axs[::2]: ax.set_ylabel("Flux")
+    fig.suptitle(title); fig.tight_layout(); fig.savefig(out_png, dpi=180); plt.close(fig)
+
+
+def plot_residuals_matrix(v_grid, resid_v, in_transit, out_png: str):
+    import matplotlib.pyplot as plt
+    v = np.asarray(v_grid, float)
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11, 4), sharey=True)
+    for r, it in zip(resid_v, in_transit):
+        (ax2 if it else ax1).plot(v, r, color="tab:blue" if not it else "tab:orange",
+                                  alpha=0.25, lw=0.6)
+    ax1.axvline(0, ls="--", color="k", alpha=0.4); ax2.axvline(0, ls="--", color="k", alpha=0.4)
+    ax1.set_title("OOT residuals"); ax2.set_title("In-transit residuals")
+    for ax in (ax1, ax2): ax.set_xlabel("Velocity [km/s]"); ax.set_xlim(v.min(), v.max())
+    ax1.set_ylabel("Residual F/F_OOT - 1")
+    fig.tight_layout(); fig.savefig(out_png, dpi=180); plt.close(fig)
+
+
+def _robust_symmetric_ylim(*ys, q=99.0, min_span=5e-4):
+    """
+    Devuelve un (ymin, ymax) simétrico alrededor de 0 a partir del percentil |y|.
+    q: percentil (99 → ignora el 1% más extremo). min_span: límite inferior.
+    """
+    import numpy as np
+    vecs = [np.ravel(y) for y in ys if y is not None]
+    if not vecs:
+        return (-1.0, 1.0)
+    v = np.concatenate(vecs)
+    v = v[np.isfinite(v)]
+    if v.size == 0:
+        return (-1.0, 1.0)
+    a = float(np.nanpercentile(np.abs(v), q))
+    a = max(a, float(min_span))
+    return (-a, +a)
 
 def plot_stack(v_grid, median, p16, p84, out_png, title="Stacked residual (planet rest)"):
     fig = plt.figure(figsize=(6, 4))
@@ -12,41 +100,505 @@ def plot_stack(v_grid, median, p16, p84, out_png, title="Stacked residual (plane
     ax.set_xlabel('Velocity [km/s]')
     ax.set_ylabel('Residual F/F_OOT - 1')
     ax.set_title(title)
+    # Escala Y robusta y simétrica
+    ymin, ymax = _robust_symmetric_ylim(median, p16, p84, q=99.0, min_span=5e-4)
+    ax.set_ylim(ymin, ymax)
     fig.tight_layout()
     fig.savefig(out_png, dpi=180)
     plt.close(fig)
-
+    
 def plot_nulls_grid(v_grid, stacks: List[tuple], out_png: str):
     fig = plt.figure(figsize=(9, 7))
     titles = [s[0] for s in stacks]
+    # Y-lim común robusto para los 4 paneles
+    all_med = [sr.median for _, sr in stacks if hasattr(sr, "median")]
+    all_p16 = [sr.p16    for _, sr in stacks if hasattr(sr, "p16")]
+    all_p84 = [sr.p84    for _, sr in stacks if hasattr(sr, "p84")]
+    ymin, ymax = _robust_symmetric_ylim(*all_med, *all_p16, *all_p84, q=99.0, min_span=5e-4)
+
     for i, (_, sr) in enumerate(stacks, start=1):
         ax = fig.add_subplot(2, 2, i)
         ax.plot(sr.v_grid, sr.median, lw=1.2)
         ax.fill_between(sr.v_grid, sr.p16, sr.p84, alpha=0.3, linewidth=0)
         ax.axvline(0.0, ls='--')
         ax.set_xlim(v_grid.min(), v_grid.max())
+        ax.set_ylim(ymin, ymax)  # misma escala en todos
         ax.set_title(titles[i-1])
         if i in (3,4): ax.set_xlabel('Velocity [km/s]')
         if i in (1,3): ax.set_ylabel('Residual')
     fig.tight_layout()
     fig.savefig(out_png, dpi=180)
     plt.close(fig)
+    
+def plot_injection_curves(inj_depths, rec_depths, rec_lo, rec_hi, out_png: str,
+                          ylim_pct: tuple | None = None, q: float = 95.0):
+    """
+    Plot recovered vs injected depth (in %), with robust y-limits.
 
-def plot_injection_curves(inj_depths, rec_depths, rec_lo, rec_hi, out_png: str):
+    ylim_pct : (ymin, ymax) in percent to force a fixed scale, e.g. (-0.2, 0.35)
+    q        : percentile used for robust auto-limits (95 → ignores top/bottom 5%)
+    """
     fig = plt.figure(figsize=(6, 5))
     ax = fig.add_subplot(111)
-    ax.errorbar(np.array(inj_depths)*100.0, np.array(rec_depths)*100.0,
-                yerr=[(np.array(rec_depths)-np.array(rec_lo))*100.0,
-                      (np.array(rec_hi)-np.array(rec_depths))*100.0],
-                fmt='o')
-    ax.plot(np.array(inj_depths)*100.0, np.array(inj_depths)*100.0, ls='--')
+
+    inj = np.asarray(inj_depths, float) * 100.0
+    rec = np.asarray(rec_depths, float)
+    lo  = np.asarray(rec_lo, float)
+    hi  = np.asarray(rec_hi, float)
+
+    # Ensure correct ordering of bounds
+    lo2 = np.minimum(lo, hi)
+    hi2 = np.maximum(lo, hi)
+
+    y       = rec * 100.0
+    yerr_lo = np.clip((rec - lo2) * 100.0, 0.0, np.inf)
+    yerr_hi = np.clip((hi2 - rec) * 100.0, 0.0, np.inf)
+
+    ax.errorbar(inj, y, yerr=[yerr_lo, yerr_hi], fmt='o', capsize=3)
+    ax.plot(inj, inj, ls='--')  # 1:1 line
+
     ax.set_xlabel('Injected depth [%]')
     ax.set_ylabel('Recovered depth [%]')
     ax.set_title('Injection–Recovery (Na I)')
+
+    # ----- sensible y-axis -----
+    if ylim_pct is not None:
+        ax.set_ylim(*ylim_pct)
+    else:
+        vals = np.concatenate([y, lo2 * 100.0, hi2 * 100.0])
+        vals = vals[np.isfinite(vals)]
+        if vals.size:
+            low  = float(np.nanpercentile(vals, 100.0 - q))
+            high = float(np.nanpercentile(vals, q))
+            # ensure the 1:1 line is fully visible
+            high = max(high, float(np.nanmax(inj) * 1.05))
+            low  = min(low,  -0.10 * float(np.nanmax(inj)))
+            ax.set_ylim(low, high)
+
     fig.tight_layout()
     fig.savefig(out_png, dpi=180)
     plt.close(fig)
-
+    
 # Backward-compat wrapper (keeps your previous function name)
 def plot_stack_velocity(v_kms, r_stack, lo=None, hi=None, centers_v=None, out_png="fig_7_1_stack.png"):
     plot_stack(v_kms, r_stack, lo if lo is not None else r_stack, hi if hi is not None else r_stack, out_png)
+    
+
+def plot_colormap_velocity(v_grid_kms, residuals_by_exp, phases, Kp_kms,
+                           out_png, title="Residuals (planet rest)",
+                           cmap="viridis", vline0=True):
+    """
+    Show residual matrix in velocity space (rows=exposures, cols=velocity bins).
+    Overlays planet trail v_p(phase)=Kp*sin(2π*phase).
+    """
+    V = np.asarray(v_grid_kms, float)
+    M = np.vstack(residuals_by_exp)  # shape [N_exp, N_v]
+    vmin, vmax = _robust_limits(M, 2, 98)
+
+    fig, ax = plt.subplots(figsize=(9, 4))
+    im = ax.imshow(M, aspect="auto", origin="lower",
+                   extent=[V.min(), V.max(), 0, M.shape[0]],
+                   vmin=vmin, vmax=vmax, cmap=cmap)
+
+    # Planet trail: one point per exposure (x=v_p, y=index)
+    v_p = Kp_kms * np.sin(2*np.pi*np.asarray(phases, float))
+#    ax.plot(v_p, np.arange(len(phases)) + 0.5, color="r", lw=1.2, alpha=0.9) --> To be confirmed with professor
+
+    if vline0:
+        ax.axvline(0.0, ls="--", lw=1.2, color="#1f77b4", alpha=0.8)
+
+    ax.set_xlabel("Velocity [km/s]")
+    ax.set_ylabel("Exposure index")
+    ax.set_title(title)
+    cbar = fig.colorbar(im, ax=ax, pad=0.02)
+    cbar.set_label("Residual  F/F$_{\\rm OOT}$ − 1")
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=160)
+    plt.close(fig)
+
+def plot_colormap_wavelength(waves_rest, fluxes, center_A, half_A,
+                             out_png, title="Flux (stellar rest)",
+                             Npix=401, continuum_norm=True, cmap="viridis"):
+    """
+    Build a common λ-grid around the line and image all exposures stacked.
+    Optionally normalizes each exposure by sideband median (continuum_norm).
+    """
+    # Common λ-grid in stellar rest frame
+    lam_lo, lam_hi = center_A - half_A, center_A + half_A
+    lam_grid = np.linspace(lam_lo, lam_hi, int(Npix))
+
+    # Interpolate each exposure to lam_grid
+    imgs = []
+    for w, f in zip(waves_rest, fluxes):
+        w = np.asarray(w, float); f = np.asarray(f, float)
+        m = (w >= lam_lo) & (w <= lam_hi) & np.isfinite(f)
+        if np.count_nonzero(m) < 5:
+            imgs.append(np.full_like(lam_grid, np.nan))
+            continue
+        fi = np.interp(lam_grid, w[m], f[m], left=np.nan, right=np.nan)
+        if continuum_norm:
+            # sidebands: exclude ±(center±30 km/s) around line
+            C_KMS = 299792.458
+            v_loc = C_KMS*(lam_grid-center_A)/center_A
+            sb = np.abs(v_loc) >= 30.0
+            cont = np.nanmedian(fi[sb]) if np.any(sb & np.isfinite(fi)) else 1.0
+            if not np.isfinite(cont) or cont == 0:
+                cont = 1.0
+            fi = fi/cont
+        imgs.append(fi)
+
+    M = np.vstack(imgs)  # [N_exp, Npix]
+    vmin, vmax = _robust_limits(M, 1, 99)
+
+    fig, ax = plt.subplots(figsize=(9, 4))
+    im = ax.imshow(M, aspect="auto", origin="lower",
+                   extent=[lam_grid.min(), lam_grid.max(), 0, M.shape[0]],
+                   vmin=vmin, vmax=vmax, cmap=cmap)
+    ax.axvline(center_A, ls="--", color="0.6")
+    ax.set_xlabel("Wavelength [Å]")
+    ax.set_ylabel("Exposure index")
+    ax.set_title(title)
+    cbar = fig.colorbar(im, ax=ax, pad=0.02)
+    cbar.set_label("Flux (normalized)" if continuum_norm else "Flux")
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=160)
+    plt.close(fig)
+    
+    
+def _sideband_mask_lambda(w, center_A, half_A, gap_kms=30.0):
+    """Sidebands: exclude ±gap_kms around the line center."""
+    gap_A = center_A * (gap_kms / C_KMS)
+    mL = (w >= center_A - half_A) & (w <= center_A - gap_A)
+    mR = (w >= center_A + gap_A) & (w <= center_A + half_A)
+    return mL | mR
+
+
+# --------------------------- utilities --------------------------------
+def _autoscale_symmetric(M, pct_lo=5, pct_hi=95):
+    """Robust symmetric color limits from percentiles of finite values."""
+    finite = np.isfinite(M)
+    if not np.any(finite):
+        return -1.0, +1.0
+    lo, hi = np.nanpercentile(M[finite], [pct_lo, pct_hi])
+    span = max(abs(lo), abs(hi), 1e-12)
+    return -span, +span
+
+
+# -------------------- STELLAR-REST: FLUX vs λ -------------------------
+def make_colormap_stellar_rest_matrix(
+    waves, fluxes, *, center_A, half_A,
+    bervs=None, rv_stars=None, Npix=401, continuum_norm=True
+):
+    """
+    Build a wavelength grid and a 2D matrix of flux in the *stellar rest* frame.
+
+    Inputs
+    ------
+    waves, fluxes    : lists of 1D arrays per exposure (same lengths)
+    center_A, half_A : line window [Å]
+    bervs, rv_stars  : per-exposure BERV and stellar RV [km/s] (optional but recommended)
+    Npix             : number of wavelength pixels in the common grid
+    continuum_norm   : if True, normalize each row by sidebands
+
+    Returns
+    -------
+    lam_grid : [Npix] common wavelength grid (stellar rest) [Å]
+    M        : [N_exp, Npix] flux matrix (normalized if continuum_norm)
+    """
+    waves = list(waves); fluxes = list(fluxes)
+
+    # 1) Shift each exposure to stellar rest (remove observer BERV & systemic RV)
+    from mvt.rv import to_stellar_rest
+    waves_rest = []
+    for i, w in enumerate(waves):
+        if (bervs is not None) and (rv_stars is not None):
+            w0 = to_stellar_rest(w, rv_star_kms=float(rv_stars[i]), berv_kms=float(bervs[i]))
+        else:
+            w0 = np.asarray(w, float)
+        waves_rest.append(w0)
+
+    # 2) Common wavelength grid around the line
+    lam_lo = center_A - half_A
+    lam_hi = center_A + half_A
+    lam_grid = np.linspace(lam_lo, lam_hi, int(Npix), dtype=float)
+
+    # 3) Interpolate each exposure onto lam_grid
+    M = []
+    for w, f in zip(waves_rest, fluxes):
+        # window, then interp
+        m = (w >= lam_lo) & (w <= lam_hi)
+        if not np.any(m):
+            M.append(np.full_like(lam_grid, np.nan))
+            continue
+        fi = np.interp(lam_grid, w[m], np.asarray(f, float)[m], left=np.nan, right=np.nan)
+
+        if continuum_norm:
+            # sidebands: |v| >= 30 km/s relative to center_A
+            v_loc = C_KMS * (lam_grid - center_A) / center_A
+            sb = np.abs(v_loc) >= 30.0
+            med = np.nanmedian(fi[sb]) if np.any(sb & np.isfinite(fi)) else np.nanmedian(fi)
+            if np.isfinite(med) and med != 0.0:
+                fi = fi / med
+        M.append(fi)
+
+    return lam_grid, np.vstack(M)
+
+
+def plot_colormap_stellar_rest(
+    lam_grid, M, out_png, *, title="Flux colormap (stellar rest)",
+    center_A=None, vmin=None, vmax=None
+):
+    """Plot stellar-rest 2D *flux* image vs wavelength (Å)."""
+    if vmin is None or vmax is None:
+        vmin, vmax = np.nanmin(M), np.nanmax(M)
+    fig = plt.figure(figsize=(12, 4))
+    ax = fig.add_subplot(111)
+    extent = [float(lam_grid.min()), float(lam_grid.max()), 0, M.shape[0]]
+    im = ax.imshow(M, aspect="auto", origin="lower", extent=extent, cmap="viridis",
+                   vmin=vmin, vmax=vmax)
+    ax.set_xlabel("Wavelength [Å]  (stellar rest)")
+    ax.set_ylabel("Exposure index")
+    if center_A is not None:
+        ax.axvline(center_A, color="w", ls="--", lw=1.8, alpha=0.7)
+    ax.set_title(title)
+    cbar = fig.colorbar(im, ax=ax)
+    cbar.set_label("Flux" + (" (normalized)" if 0.7 < np.nanmedian(M) < 1.3 else ""))
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=160)
+    plt.close(fig)
+
+
+# --------------- PLANET-REST: RESIDUALS vs λ --------------------------
+def plot_colormap_planet_rest_lambda(
+    v_grid_kms, residuals_exp_by_v, *, center_A, out_png,
+    title="Residuals colormap (planet rest, λ)",
+    vmin=None, vmax=None, pct=(5, 95), show_velocity_axis_top=False
+):
+    """
+    Plot planet-rest *residuals* vs wavelength. The input residuals are already
+    on a common velocity grid in the planet rest frame (output of STEP 4).
+
+    x-axis transform: λ = λ0 * (1 + v/c)
+    """
+    M = np.vstack(residuals_exp_by_v).astype(float)
+    lam_grid = center_A * (1.0 + np.asarray(v_grid_kms, float)/C_KMS)
+
+    # Robust symmetric colour range if not provided
+    if vmin is None or vmax is None:
+        vmin, vmax = _autoscale_symmetric(M, pct_lo=pct[0], pct_hi=pct[1])
+
+    fig = plt.figure(figsize=(12, 4))
+    ax = fig.add_subplot(111)
+    extent = [float(lam_grid.min()), float(lam_grid.max()), 0, M.shape[0]]
+    im = ax.imshow(M, aspect="auto", origin="lower", extent=extent, cmap="viridis",
+                   vmin=vmin, vmax=vmax)
+    ax.set_xlabel("Wavelength [Å]  (planet rest)")
+    ax.set_ylabel("Exposure index")
+    ax.axvline(center_A, color="w", ls="--", lw=1.8, alpha=0.7)
+    ax.set_title(title)
+    cbar = fig.colorbar(im, ax=ax)
+    cbar.set_label("Residual  F/F$_{\\rm OOT}$ − 1")
+
+    if show_velocity_axis_top:
+        # optional twin top axis to show velocity ticks for reference
+        C = C_KMS; lam0 = center_A
+        lam_to_v = lambda lam: C * (lam/lam0 - 1.0)
+        v_to_lam = lambda v: lam0 * (1.0 + v/C)
+        secax = ax.secondary_xaxis('top', functions=(lam_to_v, v_to_lam))
+        secax.set_xlabel("Velocity [km/s]")
+
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=160)
+    plt.close(fig)
+ 
+    
+ # --------------- STELLAR-REST: RESIDUALS vs λ --------------------------
+
+def make_colormap_stellar_rest_residuals_matrix(
+    waves, fluxes, *, in_transit, center_A, half_A,
+    bervs=None, rv_stars=None, Npix=401, sideband_flatten=True
+):
+    """
+    Build a 2D matrix of *residuals* in the STELLAR rest frame, on a common λ-grid.
+
+    Steps
+    -----
+    1) Shift each exposure to stellar rest using (BERV, RV_*).
+    2) Interpolate onto λ-grid around [center_A ± half_A].
+    3) Build OOT master from OOT rows only.
+    4) Residuals = F / F_OOT - 1.
+    5) (Optional) subtract per-row sideband median (|v|>=30 km/s) to flatten offsets.
+
+    Returns
+    -------
+    lam_grid : [Npix] wavelength grid (Å, stellar rest)
+    R        : [N_exp, Npix] residual matrix (dimensionless)
+    """
+    from mvt.rv import to_stellar_rest
+
+    lam_lo = float(center_A - half_A)
+    lam_hi = float(center_A + half_A)
+    lam_grid = np.linspace(lam_lo, lam_hi, int(Npix), dtype=float)
+
+    rows = []
+    for i, (w, f) in enumerate(zip(waves, fluxes)):
+        w = np.asarray(w, float); f = np.asarray(f, float)
+
+        # Shift to stellar rest (remove observer's motion + systemic RV)
+        if bervs is not None and rv_stars is not None:
+            w_rest = to_stellar_rest(w, rv_star_kms=float(rv_stars[i]), berv_kms=float(bervs[i]))
+        else:
+            w_rest = w
+
+        # Interpolate to common λ-grid within the window
+        m = (w_rest >= lam_lo) & (w_rest <= lam_hi)
+        if not np.any(m):
+            rows.append(np.full_like(lam_grid, np.nan))
+            continue
+        fi = np.interp(lam_grid, w_rest[m], f[m], left=np.nan, right=np.nan)
+        rows.append(fi)
+
+    F = np.vstack(rows)  # [N_exp, Npix]
+
+    oot = ~np.asarray(in_transit, bool)
+    if not np.any(oot):
+        raise ValueError("make_colormap_stellar_rest_residuals_matrix: no OOT rows available.")
+
+    # OOT master on the same λ-grid
+    F_oot = F[oot]
+    if not np.isfinite(F_oot).any():
+        raise ValueError("All OOT flux rows are NaN in the stellar-rest grid.")
+    oot_master = np.nanmedian(F_oot, axis=0)  # [Npix]
+    # Guard against zeros
+    good = np.isfinite(oot_master) & (oot_master != 0)
+    if not np.any(good):
+        raise ValueError("OOT master is invalid on the stellar-rest grid.")
+    # Safe divide (broadcast)
+    R = F / oot_master - 1.0
+
+    if sideband_flatten:
+        # Subtract per-row median over sidebands (|v|>=30 km/s) to zero the continuum
+        v_loc = C_KMS * (lam_grid - center_A) / center_A
+        sb = np.abs(v_loc) >= 30.0
+        if np.any(sb):
+            med = np.nanmedian(R[:, sb], axis=1)  # [N_exp]
+            R = R - med[:, None]
+
+    return lam_grid, R
+
+
+def plot_colormap_stellar_rest_residuals(
+    lam_grid, R, out_png, *,
+    title="Residuals colormap (stellar rest)",
+    center_A=None, vmin=None, vmax=None, pct=(5, 95)
+):
+    """Plot STELLAR-rest 2D *residuals* image vs wavelength (Å)."""
+    if vmin is None or vmax is None:
+        vmin, vmax = _autoscale_symmetric(R, pct_lo=pct[0], pct_hi=pct[1])
+
+    fig = plt.figure(figsize=(12, 4))
+    ax = fig.add_subplot(111)
+    extent = [float(lam_grid.min()), float(lam_grid.max()), 0, R.shape[0]]
+    im = ax.imshow(R, aspect="auto", origin="lower", extent=extent, cmap="viridis",
+                   vmin=vmin, vmax=vmax)
+    ax.set_xlabel("Wavelength [Å]  (stellar rest)")
+    ax.set_ylabel("Exposure index")
+    if center_A is not None:
+        ax.axvline(center_A, color="w", ls="--", lw=1.8, alpha=0.7)
+    ax.set_title(title)
+    cbar = fig.colorbar(im, ax=ax)
+    cbar.set_label("Residual  F/F$_{\\rm OOT}$ − 1")
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=160)
+    plt.close(fig)
+    
+# --- unified λ-space colormap plotter ---
+
+def _robust_vlim(M: np.ndarray, pct: float = 99.5, symmetric: bool = True) -> tuple[float, float]:
+    """
+    Robust color limits for residual matrices.
+    - pct: percentile of |values| if symmetric, else upper/lower percentiles.
+    """
+    vals = np.asarray(M, float)
+    vals = vals[np.isfinite(vals)]
+    if vals.size == 0:
+        return (-0.01, 0.01)  # safe default
+    if symmetric:
+        a = float(np.nanpercentile(np.abs(vals), pct))
+        a = max(a, 1e-4)  # avoid zero range
+        return (-a, +a)
+    else:
+        lo = float(np.nanpercentile(vals, (100.0 - pct) / 2.0))
+        hi = float(np.nanpercentile(vals, 100.0 - (100.0 - pct) / 2.0))
+        if not np.isfinite(lo) or not np.isfinite(hi) or lo == hi:
+            return (-0.01, 0.01)
+        return (lo, hi)
+
+def plot_colormap_lambda(
+    lam_grid_A: np.ndarray,              # [Npix]
+    M: np.ndarray,                       # [N_exp, Npix]
+    out_png: str,
+    *,
+    title: str,
+    frame: str,                          # "stellar" | "planet"
+    quantity: str,                       # "flux" | "residuals"
+    center_A: float,
+    show_velocity_axis_top: bool = False,
+    # NEW knobs
+    vlim: str | tuple[float, float] = "auto",   # "auto" or (vmin, vmax)
+    pct: float = 99.5,                          # robust percentile when auto
+    symmetric: bool = True,                     # center the scale on 0 for residuals
+    cmap: str | None = None,                    # default diverging for residuals
+):
+    lam = np.asarray(lam_grid_A, float)
+    A   = np.asarray(M, float)
+
+    # Decide color limits
+    if isinstance(vlim, (list, tuple)) and len(vlim) == 2:
+        vmin, vmax = float(vlim[0]), float(vlim[1])
+        norm = TwoSlopeNorm(vcenter=0.0, vmin=vmin, vmax=vmax) if (symmetric and quantity == "residuals") else None
+    elif vlim == "auto":
+        vmin, vmax = _robust_vlim(A, pct=pct, symmetric=(symmetric and quantity == "residuals"))
+        norm = TwoSlopeNorm(vcenter=0.0, vmin=vmin, vmax=vmax) if (symmetric and quantity == "residuals") else None
+    else:
+        vmin = vmax = None
+        norm = TwoSlopeNorm(vcenter=0.0) if (symmetric and quantity == "residuals") else None
+
+    # Pick a sensible colormap
+    if cmap is None:
+        cmap = "RdBu_r" if quantity == "residuals" else "viridis"
+
+    # Plot
+    fig = plt.figure(figsize=(12, 3.6))
+    ax = fig.add_subplot(111)
+
+    # extent maps [x_min, x_max, y_min, y_max] to imshow coordinates
+    extent = [lam.min(), lam.max(), 0, A.shape[0]]
+    im = ax.imshow(A, aspect="auto", origin="lower",
+                   extent=extent, cmap=cmap,
+                   vmin=None if norm else vmin, vmax=None if norm else vmax,
+                   norm=norm)
+
+    ax.set_xlabel("Wavelength [Å]")
+    ax.set_ylabel("Exposure index")
+    ax.set_title(f"{title} — {frame} rest, {quantity}")
+
+    # Vertical dashed line at the line center
+    ax.axvline(center_A, ls="--", color="w", alpha=0.6)
+
+    # Optional velocity ticks on top
+    if show_velocity_axis_top:
+        c = 299_792.458
+        v = c * (lam - float(center_A)) / float(center_A)
+        ax2 = ax.twiny()
+        ax2.set_xlim(v.min(), v.max())
+        ax2.set_xlabel("Velocity [km/s]")
+
+    # Colorbar
+    cbar = fig.colorbar(im, ax=ax, pad=0.02)
+    label = "Residuals (F/F_OOT − 1)" if quantity == "residuals" else "Flux"
+    cbar.set_label(label)
+
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=180)
+    plt.close(fig)

--- a/mvt/residuals.py
+++ b/mvt/residuals.py
@@ -4,20 +4,139 @@ from typing import List, Tuple, Optional
 from .timephase import Ephemeris, phases_from_bjd, compute_contacts_auto
 from .rv import to_stellar_rest, planet_rv_kms
 
+# Velocidad de la luz en km/s (aprox. exacta para nuestras necesidades)
 C_KMS = 299792.458
 
+
+# -------------------------------------------------------------------------
+# Utilidades básicas
+# -------------------------------------------------------------------------
+
 def frac_residual(flux, oot):
+    """
+    Devuelve el **residual fraccionario** r = F / F_OOT - 1.
+
+    Parámetros
+    ----------
+    flux : array-like
+        Flujo de una exposición (unidimensional).
+    oot : array-like
+        "Master" out-of-transit con la MISMA rejilla nativa (mismo tamaño).
+
+    Notas importantes
+    -----------------
+    - Este cociente asume que `flux` y `oot` están muestreados en la misma
+      rejilla de longitudes de onda (mismo índice i → misma λ_i).
+      Si tus S1D varían la rejilla entre exposiciones, hay que **re-muestrear
+      previamente** para construir `oot`.
+    """
     return np.asarray(flux, float) / np.asarray(oot, float) - 1.0
 
 def cut_window(wave, arr, center_A, half_A):
+    """
+    Recorta `arr` (flux/residual) y `wave` a la ventana [center_A ± half_A].
+
+    Devolvemos la pareja (wave_recortada, arr_recortada) para operar solo
+    alrededor de la línea de interés.
+    """
     m = (wave >= center_A - half_A) & (wave <= center_A + half_A)
     return wave[m], arr[m]
 
+# -------------------------------------------------------------------------
+# Corrección de continuo (por bandas laterales) — helpers locales
+# -------------------------------------------------------------------------
+def _sideband_mask_local(w, center_A, half_A, gap_kms=30.0):
+    """
+    Construye una máscara booleana para seleccionar **bandas laterales**:
+    regiones alejadas del centro de línea más allá de ±gap_kms, pero aún
+    dentro de la ventana [center_A ± half_A].
+
+    gap_kms se traduce a Δλ mediante la aproximación Doppler clásica:
+    Δλ = λ0 * (gap_kms / c).
+    """
+    gap_A = center_A * (gap_kms / C_KMS)
+    mL = (w >= center_A - half_A) & (w <= center_A - gap_A)
+    mR = (w >= center_A + gap_A) & (w <= center_A + half_A)
+    return mL | mR
+
+def _normalize_by_sidebands_local(w, r_raw, center_A, half_A):
+    """
+    Normaliza una **curva de cocientes** f/oot (aún NO centrada en 1) usando
+    las bandas laterales de ESA MISMA exposición y rejilla.
+
+    Estrategia:
+      1) Ajuste lineal en bandas laterales: y ≈ intercept + slope*(w-centerA)
+         → `cont(w)` como estimación de continuo multiplicativo residual.
+      2) Dividimos r_raw por `cont(w)` para aplanar el continuo.
+      3) Fallback: si no hay suficientes puntos, usar mediana de sidebands.
+
+    Entradas
+    --------
+    w : ndarray
+        Wavelength en la rejilla (idealmente ya en reposo estelar).
+    r_raw : ndarray
+        Cociente f_i / oot_master en la rejilla de la exposición (≥ 0).
+        OJO: aquí es el cociente **positivo**, no (f/oot - 1).
+    center_A, half_A : float
+        Definen la ventana de línea y por tanto las bandas laterales.
+
+    Salida
+    ------
+    r_norm : ndarray
+        r_raw / cont(w) → todavía en "cociente" (≈1 en continuo).
+        El “residual final” será r_norm - 1.
+    """
+    # Selección de sidebands y limpieza de no-finitos
+    m = _sideband_mask_local(w, center_A, half_A) & np.isfinite(r_raw)
+    if np.count_nonzero(m) >= 5:
+        # Ajuste lineal sobre w-center_A para estabilidad numérica
+        x = w[m] - center_A
+        y = r_raw[m]
+        slope, intercept = np.polyfit(x, y, 1)   # y ≈ intercept + slope*x
+
+        # Continuo multiplicativo estimado y topes de seguridad
+        cont = intercept + slope * (w - center_A)
+        cont = np.clip(cont, 1e-3, 1e3)          # evita divisiones raras
+        return r_raw / cont
+
+    # Fallback: scale by sideband median if not enough points
+    med = np.nanmedian(r_raw[m]) if np.any(m) else 1.0
+    return r_raw / med
+
 def residual_on_vgrid_with_shift(wave, resid, center_A, v_grid_kms, v_shift_kms):
+    """
+    Interpola un residual (en función de λ) a una rejilla de velocidades
+    `v_grid_kms`, previa conversión λ→v y **tras restar** el corrimiento
+    `v_shift_kms` (p.ej. velocidad planetaria para llevar la línea a v≈0).
+
+    Notas
+    -----
+    - La conversión usa Doppler clásico (válido para |v|≪c):
+        v = c * (λ - λ0)/λ0
+    - Usamos np.interp con `left/right=np.nan`: fuera del rango se devolverán
+      NaNs y luego los procedimientos de “stack” usarán nanmedian/nanpercentile.
+    """
+    """
+    Interpola un residual (en función de λ) a una rejilla de velocidades
+    `v_grid_kms`, previa conversión λ→v y **tras restar** el corrimiento
+    `v_shift_kms` (p.ej. velocidad planetaria para llevar la línea a v≈0).
+
+    Notas
+    -----
+    - La conversión usa Doppler clásico (válido para |v|≪c):
+        v = c * (λ - λ0)/λ0
+    - Usamos np.interp con `left/right=np.nan`: fuera del rango se devolverán
+      NaNs y luego los procedimientos de “stack” usarán nanmedian/nanpercentile.
+    """
+
+
     v = C_KMS * (np.asarray(wave, float) - float(center_A)) / float(center_A)
     x = v - float(v_shift_kms)
     return np.interp(v_grid_kms, x, resid, left=np.nan, right=np.nan)
 
+# -------------------------------------------------------------------------
+# Función principal: construir residuos sobre rejilla de velocidad
+# -------------------------------------------------------------------------
 def make_residuals_and_vgrid(waves: List[np.ndarray],
                              fluxes: List[np.ndarray],
                              bjds: np.ndarray,
@@ -33,15 +152,43 @@ def make_residuals_and_vgrid(waves: List[np.ndarray],
                              contacts=None,
                              it_mask: Optional[np.ndarray] = None
                              ) -> Tuple[np.ndarray, List[np.ndarray]]:
-    """Build residuals r=F/F_OOT−1, align to planet rest frame at a velocity grid.
-
-    Returns
-    -------
-    v_grid : ndarray [km/s]
-    resid_v : list of ndarray, one per exposure on v_grid
     """
+    Construye perfiles residuos alineados en la **rejilla de velocidad**
+    del marco planetario y devuelve también esa rejilla común.
+
+    Pasos (resumen)
+    ---------------
+    1) Determinar exposiciones in-transit (mask) **en espacio de fase**.
+    2) Pasar cada rejilla λ[i] a **reposo estelar** si hay (BERV, RV_*).
+    3) Construir OOT master en la rejilla nativa (suponiendo misma rejilla).
+    4) Residuales por exposición:
+         r_raw = f_i/oot_master  → normalizar continuo con sidebands →
+         residual final = r_norm - 1.
+    5) Definir rejilla de velocidades v_grid = [vmin:dv:vmax].
+    6) Para cada exposición:
+         recortar ventana [λ0 ± Δλ] → pasar a v_local → restar v_planeta
+         → interpolar a v_grid → residual en la rejilla común.
+    7) Devolver (v_grid, lista_de_perfiles_residuales).
+
+    Unidades/convenciones
+    ---------------------
+    - `waves[i]` y `fluxes[i]` deben ser 1D y **coherentes entre sí**.
+    - `center_A` y `half_width_A` en **Ångström**.
+    - `vmin`, `vmax`, `dv` en **km/s**.
+    - La salida son perfiles **adimensionales** (F/F_OOT - 1) en v_grid.
+
+    Supuestos y precauciones
+    ------------------------
+    - **Importante**: para construir `oot_master` hacemos una mediana por
+      columnas de `F_oot = [f_j]` tal cual. Esto **asume** que las rejillas
+      nativas de todas las exposiciones son idénticas (mismo N y misma λ_i).
+      Si no es tu caso, antes hay que re-muestrear los `f_j` a una rejilla
+      común en λ (o construir OOT directamente en velocidad).
+    - Si no hay OOT suficientes se lanza `ValueError`.
+    """    
     bjds = np.asarray(bjds, float)
-    # Derive (or accept) in-transit mask in PHASE space (contacts are phases)
+
+    # 1) Derive (or accept) in-transit mask in PHASE space (contacts are phases)
     if it_mask is None:
         if contacts is None:
             contacts = compute_contacts_auto(ephem)  # T1..T4 in phase units
@@ -50,7 +197,7 @@ def make_residuals_and_vgrid(waves: List[np.ndarray],
     else:
         it_mask = np.asarray(it_mask, bool)
 
-    # Shift each to stellar rest if RV info supplied
+    # 2) Shift each to stellar rest if RV info supplied
     w_rest = []
     for i, w in enumerate(waves):
         if bervs is not None and rv_stars is not None:
@@ -59,7 +206,7 @@ def make_residuals_and_vgrid(waves: List[np.ndarray],
             w0 = np.asarray(w, float)
         w_rest.append(w0)
 
-    # Build OOT master on native grid
+    # 3) Build OOT master on native grid
     oot_mask = ~it_mask
 
     F_oot = [f for f, m in zip(fluxes, oot_mask) if m]
@@ -68,25 +215,52 @@ def make_residuals_and_vgrid(waves: List[np.ndarray],
         raise ValueError(f"No OOT exposures available (IT={n_it}, OOT={n_oot}). "
                          "Check contact phases / mask input.")
 
+    # Comprobación de saneado básico (evitar todo-NaN)
     _valid = [f for f in F_oot if f is not None and np.size(f) > 0 and np.isfinite(f).any()]
     if not _valid:
         raise ValueError("No valid out-of-transit flux arrays (all empty or NaN).")
+
+    # ¡Asume misma rejilla nativa! (ver notas en docstring)
     oot_master = np.nanmedian(np.vstack(F_oot), axis=0)
 
-    # Residuals per exposure
-    resid = [frac_residual(f, oot_master) for f in fluxes]
-
-    # Velocity grid
+    # 4) Residuals per exposure (normalize by sidebands first)
+    #    Usamos sidebands de esa misma exposición para aplanar r_raw = f/oot.
+    resid = []
+    for i, f in enumerate(fluxes):
+        # r_raw es el cociente positivo (≈1 en continuo)
+        r_raw  = frac_residual(f, oot_master) + 1.0           # = f / oot_master
+        # Normaliza continuo por bandas laterales en la rejilla de esta expo
+        r_norm = _normalize_by_sidebands_local(w_rest[i], r_raw, center_A, half_width_A)
+        # Residual final (F/F_OOT - 1), ya con continuo aplanado
+        resid.append(r_norm - 1.0)                             # final residual
+        
+    # 5) Velocity grid common for all exposures
     v_grid = np.arange(vmin, vmax + dv, dv, dtype=float)
 
-    # Planet velocities per exposure (requires phases)
+    # 6) Planet velocities per exposure (requires phases) --> (llevar la señal a v≈0)
     phases = phases_from_bjd(bjds, ephem.T0_bjdtdb, ephem.period_days)
     v_p = planet_rv_kms(phases, ephem.Kp_kms)
 
-    # Window + rebin each residual onto v_grid, shifted by v_p
+    # 7) Ventana + λ→v + (−v_planeta) + interpolación a v_grid
     resid_v = []
     for i in range(len(resid)):
+        # Recorte a ventana de línea en λ (ya en reposo estelar)
         w_i, r_i = cut_window(w_rest[i], resid[i], center_A, half_width_A)
+
+        # --- OPCIONAL: quita tendencia lineal usando sidebands ---
+        #   - define velocidad local en la ventana (sin marco planetario)
+        #   - usa |v| >= 30 km/s como bandas laterales
+        #   - ajusta recta y la resta del residual de esta exposición
+        v_loc = (C_KMS * (w_i - center_A) / center_A).astype(float)
+        sb = (np.abs(v_loc) >= 30.0)              # bandas laterales
+        if np.isfinite(r_i[sb]).sum() >= 5:
+            a, b = np.polyfit(v_loc[sb], r_i[sb], 1)
+            r_i = r_i - (a * v_loc + b)
+        # --- fin opcional ---
+
+        # Interpolación a la rejilla común **substraída** la velocidad planetaria
         rv_i = residual_on_vgrid_with_shift(w_i, r_i, center_A, v_grid, v_p[i])
         resid_v.append(rv_i)
+
+    # Salidas para el resto del pipeline (stack, ajuste, nulos, inyección,…)
     return v_grid, resid_v

--- a/mvt/run_mvt_espre.py
+++ b/mvt/run_mvt_espre.py
@@ -2,25 +2,6 @@
 # -*- coding: utf-8 -*-
 """
 ESPRESSO Na I D₂ Transmission Pipeline — single-night reduction
-
-This script is intentionally written as a *readable pipeline*: each step has a
-clear *aim*, states the *problem it solves*, and documents *inputs/outputs* with
-units and shapes. Variable names include unit suffixes for fast scanning:
-
-    _A    : Angstroms
-    _kms  : Kilometers per second
-    _bjd  : BJD_TDB timestamps
-
-High-level flow:
-    1) Load configuration & make output folders
-    2) Load orbital ephemeris & compute contact times
-    3) Discover & read S1D exposures
-    4) Build residuals in velocity space around Na I D2
-    5) (Optional) Detrend exposure-level systematics
-    6) Stack residuals (median) and spread (p16/p84)
-    7) Fit Gaussian line to stacked profile
-    8) Run null tests (QC)
-    9) Injection–recovery (sensitivity curve)
 """
 
 from __future__ import annotations
@@ -36,15 +17,18 @@ import numpy.typing as npt
 from mvt.discover import list_s1d_files
 from mvt.io_espre import read_s1d
 from mvt.timephase import Ephemeris, contacts_from_yaml, phases_from_bjd, in_transit_mask
-from mvt.residuals import make_residuals_and_vgrid
-from mvt.fitlines import fit_gaussian_velocity  # canonical fitter (init_sigma_kms positional)
-from mvt.plots import plot_stack, plot_nulls_grid, plot_injection_curves
-from mvt.saveio import write_table71, write_injection_csv
+from mvt.fitlines import fit_gaussian_velocity
+from mvt.plots import plot_stack, plot_nulls_grid
+from mvt.saveio import write_table71
 from mvt.nulls import (
     null_oot_only, null_wrong_rest_frame, null_phase_shuffle, null_control_window
 )
-from mvt.injection import inject_into_residuals, make_nonneg_yerr
 from mvt.stack import robust_nanmedian
+
+# colour-map helpers (single unified API, wavelength x-axis only)
+from mvt.matrix import make_matrix_lambda
+from mvt.plots  import plot_colormap_lambda, plot_window_examples, plot_residuals_matrix
+from mvt.rv     import to_stellar_rest
 
 # ----------------------------------------------------------------------------- #
 # Constants
@@ -56,7 +40,6 @@ C_KMS: float = 299_792.458  # speed of light [km/s]
 # Small helpers kept near the pipeline for readability
 # ----------------------------------------------------------------------------- #
 def _default_cfg_path() -> str:
-    """Return default YAML config path within the repo."""
     repo_root = Path(__file__).resolve().parents[1]
     return str(repo_root / "configs" / "hd189733_naid.yaml")
 
@@ -68,29 +51,11 @@ def _fit_amp_from_profile(
     init_sigma_kms: float,
     center_kms: float = 0.0,
 ) -> float:
-    """
-    Step-local utility: fit a Gaussian within ±window_kms around center_kms and
-    return the absolute amplitude |A| (≈ line depth in residual units).
-
-    Inputs
-    ------
-    v_grid_kms    : [N_v] velocity grid [km/s]
-    profile       : [N_v] residual profile (dimensionless; flux ratio – 1)
-    window_kms    : half-window around center [km/s]
-    init_sigma_kms: initial σ for the fitter [km/s]
-    center_kms    : fit center in velocity space [km/s], default 0 in planet RF
-
-    Output
-    ------
-    |A| (float): absolute amplitude (dimensionless). If fit is ill-posed,
-    returns NaN.
-    """
     mwin = (v_grid_kms >= center_kms - window_kms) & (v_grid_kms <= center_kms + window_kms)
     if np.count_nonzero(mwin) < 5 or not np.any(np.isfinite(profile[mwin])):
         return np.nan
-    # We pass center_A for completeness; EW is not used here, only amplitude.
     fit = fit_gaussian_velocity(v_grid_kms[mwin], profile[mwin], init_sigma_kms, center_A=5895.924)
-    return float(abs(getattr(fit, "depth", np.nan)))  # 'depth' is positive by convention
+    return float(abs(getattr(fit, "depth", np.nan)))
 
 
 def _bootstrap_amp(
@@ -101,30 +66,13 @@ def _bootstrap_amp(
     nboot: int = 1000,
     rng: np.random.Generator | int | None = None,
 ) -> Tuple[float, float, float]:
-    """
-    Bootstrap the *stacked* amplitude: resample exposures with replacement,
-    stack by robust median, fit |A| each time, then return (median, p16, p84).
-
-    Inputs
-    ------
-    v_grid_kms         : [N_v]
-    profiles_exp_by_v  : [N_exp, N_v] residual profiles (dimensionless)
-    window_kms         : half-window for Gaussian fit [km/s]
-    init_sigma_kms     : initial σ [km/s]
-    nboot              : # bootstrap iterations
-    rng                : seed or Generator
-
-    Outputs
-    -------
-    (A_med, A_lo, A_hi): amplitude distribution summary, dimensionless
-    """
     rng = np.random.default_rng(rng)
     profiles = np.asarray(profiles_exp_by_v, float)
     n_exp = profiles.shape[0]
     amps: List[float] = []
     for _ in range(int(nboot)):
         idx = rng.integers(0, n_exp, size=n_exp)
-        stack = robust_nanmedian(profiles[idx], axis=0, min_valid=3)  # [N_v]
+        stack = robust_nanmedian(profiles[idx], axis=0, min_valid=3)
         amps.append(_fit_amp_from_profile(v_grid_kms, stack, window_kms, init_sigma_kms))
     amps_arr = np.asarray(amps, float)
     a_med = float(np.nanmedian(amps_arr))
@@ -134,27 +82,26 @@ def _bootstrap_amp(
     return a_med, a_lo, a_hi
 
 
+def _sideband_metrics(w, f, center_A, half_A, gap_kms=30.0):
+    gap_A = center_A * (gap_kms / C_KMS)
+    mL = (w >= center_A - half_A) & (w <= center_A - gap_A)
+    mR = (w >= center_A + gap_A) & (w <= center_A + half_A)
+    L = np.nanmedian(f[mL]) if np.any(mL) else np.nan
+    R = np.nanmedian(f[mR]) if np.any(mR) else np.nan
+    x = np.concatenate([w[mL], w[mR]])
+    y = np.concatenate([f[mL], f[mR]])
+    slope = np.nan
+    if np.sum(np.isfinite(x) & np.isfinite(y)) >= 3:
+        coeff = np.polyfit(x - center_A, y, 1)
+        slope = coeff[0]
+    return L, R, slope
+
+
 # ----------------------------------------------------------------------------- #
 # Main pipeline
 # ----------------------------------------------------------------------------- #
 def main() -> None:
-
-    # ──────────────────────────────────────────────────────────────────────
-    # STEP 1 — Load configuration & prepare output folders
-    #
-    # Aim: Centralize all tunables (paths, line definitions, fitting params).
-    # Problem: Reproducibility & portability; we avoid hard-coded values.
-    #
-    # Inputs:
-    #   cfg_path : str (CLI --cfg | $MVT_CFG | default YAML)
-    #
-    # Outputs:
-    #   cfg       : dict with all parameters
-    #   fig_dir   : output/figures path
-    #   tab_dir   : output/tables  path
-    # Notes:
-    #   - Folders are created if missing to keep later code simple.
-    # ──────────────────────────────────────────────────────────────────────
+    # ── STEP 1 — Config & folders ─────────────────────────────────────────
     p = argparse.ArgumentParser()
     p.add_argument("--cfg", default=None, help="Path to YAML config")
     args = p.parse_args()
@@ -172,18 +119,10 @@ def main() -> None:
     os.makedirs(fig_dir, exist_ok=True)
     os.makedirs(tab_dir, exist_ok=True)
 
-    # ──────────────────────────────────────────────────────────────────────
-    # STEP 2 — Load ephemeris & contact times (BJD_TDB)
-    #
-    # Aim: Place exposures in orbital phase and define in-transit window.
-    # Problem: We need precise timing to build planetary rest-frame residuals.
-    #
-    # Inputs (cfg.ephemeris):
-    #   T0_bjdtdb [BJD_TDB], period_days [day], b, Rp/Rs, a/Rs, inc_deg, Kp_kms
-    # Outputs:
-    #   eph      : Ephemeris object
-    #   contacts : (t1,t2,t3,t4) inferred or from YAML
-    # ──────────────────────────────────────────────────────────────────────
+    # define debug dict (fixes NameError on dbg.get(...))
+    dbg = cfg.get("debug", {})
+
+    # ── STEP 2 — Ephemeris & contacts ─────────────────────────────────────
     eph = Ephemeris(
         T0_bjdtdb   = cfg["ephemeris"]["T0_bjdtdb"],
         period_days = cfg["ephemeris"]["period_days"],
@@ -195,21 +134,16 @@ def main() -> None:
     )
     contacts = contacts_from_yaml(eph, cfg.get("contacts"))
 
-    # ──────────────────────────────────────────────────────────────────────
-    # STEP 3 — Discover & read S1D exposures
-    #
-    # Aim: Load per-exposure spectra & metadata.
-    # Problem: Different files, different wavelength sampling per exposure.
-    #
-    # Outputs (lists of length N_exp):
-    #   wavelength_A[i] : [N_λ_i] Angstrom grid
-    #   flux[i]         : [N_λ_i] flux (instrumental units)
-    #   bjd_tdb[i]      : scalar mid-exposure [BJD_TDB]
-    #   berv_kms[i]     : scalar BERV [km/s]
-    #   rv_star_kms[i]  : scalar stellar RV [km/s]
-    # Pitfalls:
-    #   - NaNs/zeros in flux: handled later in residual construction/stack.
-    # ──────────────────────────────────────────────────────────────────────
+    # line choice from YAML
+    lines_dict = cfg["lines"]
+    line_key   = cfg.get("target_line", next(iter(lines_dict)))
+    line_cfg   = lines_dict[line_key]
+    center_A   = float(line_cfg["center_A"])
+    half_A     = float(line_cfg["half_width_A"])
+    line_label = line_cfg.get("label", f"{line_key} ({center_A:.3f} Å)")
+    INPUT_FRAME = cfg.get("input_frame", "native")
+    
+    # ── STEP 3 — Discover & read S1D exposures ────────────────────────────
     files = list_s1d_files(night_dir)
     wavelength_A: List[npt.NDArray[np.floating]] = []
     flux:         List[npt.NDArray[np.floating]] = []
@@ -221,55 +155,179 @@ def main() -> None:
         wavelength_A.append(w_A); flux.append(f)
         bjd_tdb.append(float(bjd)); berv_kms.append(float(berv)); rv_star_kms.append(float(rv_star))
 
-    bjd_tdb_arr = np.asarray(bjd_tdb, float)  # [N_exp]
+    bjd_tdb_arr = np.asarray(bjd_tdb, float)
     phases      = phases_from_bjd(bjd_tdb_arr, eph.T0_bjdtdb, eph.period_days)
-    in_transit  = in_transit_mask(bjd_tdb_arr, contacts)  # [N_exp] boolean
+    in_transit  = in_transit_mask(bjd_tdb_arr, contacts, eph)
 
-    # ──────────────────────────────────────────────────────────────────────
-    # STEP 4 — Build residuals & velocity grid around Na I D2
-    #
-    # Aim: Express each exposure in *velocity space* around the target line and
-    #      in the *planetary rest frame*; then form residuals (flux/oot - 1).
-    # Problem: Wavelength grids differ across exposures and the signal is in
-    #          velocity; we need a common v-grid and consistent normalization.
-    #
-    # Inputs:
-    #   center_A, half_A : line center and half-width [Å] from cfg.lines.NaID2
-    #   wavelength_A, flux, bjd_tdb_arr, eph, berv_kms, rv_star_kms
-    # Outputs:
-    #   velocity_grid_kms : [N_v] common velocity grid [km/s]
-    #   residual_profiles : [N_exp, N_v] dimensionless residuals
-    # Pitfalls:
-    #   - OOT definition errors → NaNs; handled by nan-aware stats later.
-    # ──────────────────────────────────────────────────────────────────────
-    center_A : float = cfg["lines"]["NaID2"]["center_A"]
-    half_A   : float = cfg["lines"]["NaID2"]["half_width_A"]
-    velocity_grid_kms, residual_profiles = make_residuals_and_vgrid(
-        wavelength_A, flux, bjd_tdb_arr, eph,
+    if dbg.get("enable", True):
+        from mvt.plots import plot_phase_coverage
+        out_pc = os.path.join(
+            fig_dir,
+            cfg.get("figures", {}).get("phase_coverage_png", "phase_coverage.png")
+        )
+        plot_phase_coverage(phases, in_transit, contacts, out_pc)
+
+        # Optional: exposures QC table (same as before)
+        qc_path = os.path.join(tab_dir, "exposures_qc.csv")
+        with open(qc_path, "w") as f:
+            f.write("idx,filename,bjd,phase,in_transit,berv_kms,rv_star_kms\n")
+            for i, p in enumerate(files):
+                f.write(f"{i},{Path(p).name},{bjd_tdb_arr[i]:.6f},{phases[i]:+.6f},"
+                        f"{int(in_transit[i])},{berv_kms[i]:.3f},{rv_star_kms[i]:.3f}\n")
+
+    # --- COLOUR MAPS in λ (stellar rest) ---
+    fig_opts = cfg.get("figures", {})
+    vlim_resid = fig_opts.get("colormap_vlim_resid", "auto")
+    vlim_flux  = fig_opts.get("colormap_vlim_flux", "auto")
+    pct        = float(fig_opts.get("colormap_percentile", 99.5))
+    sym        = bool(fig_opts.get("colormap_symmetric", True))
+    cmap_resid = fig_opts.get("colormap_cmap_resid", "RdBu_r")
+
+
+    # Flux in stellar rest
+    lam_sr, F_sr, _ = make_matrix_lambda(
+        wavelength_A, flux,
+        frame="stellar", quantity="flux",
+        center_A=center_A, half_A=half_A,
         bervs=berv_kms, rv_stars=rv_star_kms,
-        center_A=center_A, half_width_A=half_A,
-        contacts=contacts,
-        it_mask=in_transit
+        in_transit=in_transit,
+        Npix=cfg.get("figures", {}).get("colormap_Npix", 401),
+        input_frame=INPUT_FRAME,
+#        subtract_additive_trend=cfg.get("residuals", {}).get("subtract_additive_trend", True),
+        trend_gap_kms=cfg.get("residuals", {}).get("sideband_gap_kms", 40.0),
+    )
+    plot_colormap_lambda(
+        lam_sr, F_sr,
+        os.path.join(fig_dir, cfg["figures"].get("colormap_stellar_flux_png", "colormap_stellar_flux.png")),
+        title=f"Flux colormap (stellar rest) — {line_label}",
+        frame="stellar", quantity="flux", center_A=center_A,
+        vlim=vlim_flux, pct=pct, symmetric=False, cmap="viridis",
     )
 
-    # ──────────────────────────────────────────────────────────────────────
-    # STEP 5 — (Optional) Detrend exposure-level systematics
-    #
-    # Aim: Remove exposure-to-exposure trends correlated with activity proxies.
-    # Problem: Stellar/instrumental systematics can bias the stacked depth.
-    #
-    # Method:
-    #   - Build a depth proxy per exposure by integrating residuals near line.
-    #   - Robust linear model (RLM) on OOT exposures vs. chosen predictors.
-    #   - Apply model to all exposures as a scaling correction on profiles.
-    #
-    # Inputs:
-    #   cfg.detrend.enable, cfg.actin_csv, predictors list
-    # Outputs:
-    #   residual_profiles_for_stack : [N_exp, N_v] corrected residuals
-    # Pitfalls:
-    #   - Mismatched timestamps → we align via nearest-match indices.
-    # ──────────────────────────────────────────────────────────────────────
+    # Residuals in stellar rest
+    lam_sr, R_sr, _ = make_matrix_lambda(
+        wavelength_A, flux,
+        frame="stellar", quantity="residuals",
+        center_A=center_A, half_A=half_A,
+        bervs=berv_kms, rv_stars=rv_star_kms,
+        in_transit=in_transit,
+        Npix=cfg.get("figures", {}).get("colormap_Npix", 401),
+        sideband_flatten=True,
+        input_frame=INPUT_FRAME,
+        subtract_additive_trend=cfg.get("residuals", {}).get("subtract_additive_trend", True),
+        trend_gap_kms=cfg.get("residuals", {}).get("sideband_gap_kms", 40.0),
+    )
+    plot_colormap_lambda(
+        lam_sr, R_sr,
+        os.path.join(fig_dir, cfg["figures"].get("colormap_stellar_resid_png", "colormap_stellar_resid.png")),
+        title=f"Residuals colormap (stellar rest) — {line_label}",
+        frame="stellar", quantity="residuals", center_A=center_A,
+        show_velocity_axis_top=False,
+        vlim=vlim_resid, pct=pct, symmetric=sym, cmap=cmap_resid,
+    )
+
+    # ── STEP 4 — Residuals in λ (planet rest) + λ colormap ────────────────
+    # (and velocity grid for downstream steps)
+    # Audit B: raw windows (use stellar-rest wavelengths for clearer center)
+    if dbg.get("enable", True):
+        w_stellar = [
+            to_stellar_rest(wavelength_A[i], rv_star_kms=rv_star_kms[i], berv_kms=berv_kms[i])
+            if (berv_kms is not None and rv_star_kms is not None) else np.asarray(wavelength_A[i], float)
+            for i in range(len(wavelength_A))
+        ]
+        # choose a few exposures
+        idx_oot = [i for i, it in enumerate(in_transit) if not it]
+        idx_it  = [i for i, it in enumerate(in_transit) if it]
+        idxs = (idx_oot[:1] + idx_it[:2] + idx_oot[-1:]) or list(range(min(4, len(files))))
+        plot_window_examples(w_stellar, flux, center_A, half_A, idxs,
+                             os.path.join(fig_dir, "window_examples.png"))
+
+        # sideband metrics CSV on native flux
+        sb_csv = os.path.join(tab_dir, "sideband_metrics.csv")
+        with open(sb_csv, "w") as f:
+            f.write("idx,bjd,phase,in_transit,med_left,med_right,slope_perA\n")
+            for i in range(len(files)):
+                L, R, s = _sideband_metrics(wavelength_A[i], flux[i], center_A, half_A)
+                f.write(f"{i},{bjd_tdb_arr[i]:.6f},{phases[i]:+.6f},{int(in_transit[i])},"
+                        f"{L:.6g},{R:.6g},{s:.6g}\n")
+
+    # Planet-rest residuals on common λ-grid
+    lam_pr, R_pr, v_plan = make_matrix_lambda(
+        wavelength_A, flux,
+        frame="planet", quantity="residuals",
+        center_A=center_A, half_A=half_A,
+        bervs=berv_kms, rv_stars=rv_star_kms,
+        phases=phases, Kp_kms=eph.Kp_kms,
+        in_transit=in_transit,
+        Npix=cfg.get("figures", {}).get("colormap_Npix", 401),
+        sideband_flatten=True,
+        input_frame=INPUT_FRAME,
+        subtract_additive_trend=cfg.get("residuals", {}).get("subtract_additive_trend", True),
+        trend_gap_kms=cfg.get("residuals", {}).get("sideband_gap_kms", 40.0),
+    )
+
+    # Planet-rest λ colormap (with velocity tick marks on top)
+    plot_colormap_lambda(
+        lam_pr, R_pr,
+        os.path.join(fig_dir, cfg.get("figures", {}).get("colormap_planet_lambda_png", "colormap_planet_lambda.png")),
+        title=f"Residuals colormap (planet rest) — {line_label}",
+        frame="planet", quantity="residuals", center_A=center_A,
+        show_velocity_axis_top=True,
+        vlim=vlim_resid, pct=pct, symmetric=sym, cmap=cmap_resid,
+    )
+
+    # Make velocity x-axis for later steps
+    velocity_grid_kms = C_KMS * (lam_pr - center_A) / center_A   # 1D
+    residual_profiles = [row for row in R_pr]                    # list of 1D
+
+    # ---- Frame QA (guarded) -------------------------------------------------
+    if cfg.get("frameqa", {}).get("enable", True):
+        try:
+            from mvt.frameqa import run_frame_qa
+        except Exception as exc:  # import failed
+            if dbg.get("enable", True):
+                print(f"[frame QA import skipped] {exc!r}")
+        else:
+            try:
+                run_frame_qa(
+                    wavelength_A, flux,
+                    lam_sr, R_sr,                 # stellar-rest residuals (STEP 3)
+                    lam_pr, R_pr,                 # planet-rest residuals (STEP 4)
+                    bjd_tdb_arr, phases, in_transit,
+                    berv_kms, rv_star_kms,
+                    center_A, half_A,
+                    cfg, fig_dir, tab_dir,
+                    input_frame=INPUT_FRAME       # ← pass your YAML input_frame
+                )
+            except Exception as exc:  # function raised
+                if dbg.get("enable", True):
+                    print(f"[frame QA run skipped] {exc!r}")
+
+
+    # ── AUDIT C — Residuals matrix & NaN map ──────────────────────────────
+    if dbg.get("enable", True):
+        plot_residuals_matrix(velocity_grid_kms, residual_profiles, in_transit,
+                              os.path.join(fig_dir, "residuals_matrix.png"))
+        try:
+            import matplotlib.pyplot as plt
+            isfin = np.asarray([np.isfinite(r) for r in residual_profiles], bool)
+            fig = plt.figure(figsize=(7, 4)); ax = fig.add_subplot(111)
+            ax.imshow(isfin, aspect="auto", origin="lower",
+                      extent=[velocity_grid_kms.min(), velocity_grid_kms.max(), 0, isfin.shape[0]])
+            ax.set_xlabel("Velocity [km/s]"); ax.set_ylabel("Exposure index")
+            ax.set_title("Finite coverage mask"); fig.tight_layout()
+            fig.savefig(os.path.join(fig_dir, "nanmask.png"), dpi=160); plt.close(fig)
+        except Exception:
+            pass
+        v_lo, v_hi = (dbg.get("off_line_kms") or [-120.0, -80.0])
+        j = (velocity_grid_kms >= v_lo) & (velocity_grid_kms <= v_hi)
+        base = [np.nanmedian(r[j]) for r in residual_profiles]
+        with open(os.path.join(tab_dir, "residual_baseline.csv"), "w") as f:
+            f.write("idx,bjd,phase,in_transit,baseline_offline\n")
+            for i, b in enumerate(base):
+                f.write(f"{i},{bjd_tdb_arr[i]:.6f},{phases[i]:+.6f},{int(in_transit[i])},{b:.6g}\n")
+
+    # ── STEP 5 — Optional detrend ─────────────────────────────────────────
     residual_profiles_for_stack = residual_profiles
     if cfg.get("detrend", {}).get("enable", False) and cfg.get("actin_csv"):
         from mvt.detrend import (
@@ -289,187 +347,81 @@ def main() -> None:
         depth_proxy = depth_proxy_per_exposure(velocity_grid_kms, residual_profiles, half_window_kms)[keep]
         oot = (~in_transit)[keep]
 
-        y_hat, params = rlm_detrend(depth_proxy[oot], X[oot])  # fit on OOT only
+        y_hat, params = rlm_detrend(depth_proxy[oot], X[oot])
         import statsmodels.api as sm
         yhat_all = sm.add_constant(X, has_constant="add") @ params
 
-        yhat_full = np.zeros_like(bjd_tdb_arr)
-        yhat_full[keep] = yhat_all
+        yhat_full = np.zeros_like(bjd_tdb_arr); yhat_full[keep] = yhat_all
         residual_profiles_for_stack = apply_detrend_to_profiles(
             velocity_grid_kms, residual_profiles, yhat_full, init_sigma_kms
         )
 
-    # ──────────────────────────────────────────────────────────────────────
-    # STEP 6 — Stack residuals (median) and spread (p16/p84)
-    #
-    # Aim: Increase S/N while remaining robust to outliers and NaNs.
-    # Problem: Individual residuals are noisy; median stack stabilizes depth.
-    #
-    # Inputs:
-    #   residual_profiles_for_stack : [N_exp, N_v]
-    # Outputs:
-    #   stack_median : [N_v], stack_p16 : [N_v], stack_p84 : [N_v]
-    # ──────────────────────────────────────────────────────────────────────
-
-    # --- Trim to columns that are covered by at least one exposure ---
-    stack_matrix = np.vstack(residual_profiles_for_stack)           # [N_exp, N_v]
-    valid_cols = np.isfinite(stack_matrix).any(axis=0)               # [N_v] bool
+    # ── STEP 6 — Stack residuals ──────────────────────────────────────────
+    stack_matrix = np.vstack(residual_profiles_for_stack)
+    valid_cols = np.isfinite(stack_matrix).any(axis=0)
 
     velocity_grid_kms = velocity_grid_kms[valid_cols]
     residual_profiles_for_stack = [row[valid_cols] for row in residual_profiles_for_stack]
-    stack_matrix = np.vstack(residual_profiles_for_stack)            # recompute on trimmed grid
+    stack_matrix = np.vstack(residual_profiles_for_stack)
 
-    stack_matrix = np.vstack(residual_profiles_for_stack)  # [N_exp, N_v]
     stack_median = np.nanmedian(stack_matrix, axis=0)
     stack_p16    = np.nanpercentile(stack_matrix, 16, axis=0)
     stack_p84    = np.nanpercentile(stack_matrix, 84, axis=0)
 
-    # ──────────────────────────────────────────────────────────────────────
-    # STEP 7 — Fit Gaussian to the stacked line
-    #
-    # Aim: Quantify the detection: depth, centroid velocity, width, and EW.
-    # Problem: We need a compact, comparable summary of the line profile.
-    #
-    # Inputs:
-    #   velocity_grid_kms : [N_v]
-    #   stack_median      : [N_v]
-    #   init_sigma_kms    : from cfg.fit.init_sigma_A
-    # Outputs:
-    #   line_fit.depth (dimensionless), line_fit.v0_kms, line_fit.sigma_kms,
-    #   line_fit.ew_A [Å]
-    # Notes:
-    #   - `fit_gaussian_velocity` expects init_sigma_kms as 3rd positional arg.
-    # ──────────────────────────────────────────────────────────────────────
+    # OOT vs IT stacks
+    if dbg.get("enable", True):
+        A = np.vstack(residual_profiles_for_stack)
+        A_oot = A[~in_transit]; A_it = A[in_transit]
+        def _stack(arr):
+            return (np.nanmedian(arr, 0),
+                    np.nanpercentile(arr, 16, 0),
+                    np.nanpercentile(arr, 84, 0))
+        if A_oot.size:
+            m, p16, p84 = _stack(A_oot)
+            plot_stack(velocity_grid_kms, m, p16, p84,
+                       os.path.join(fig_dir, "stack_OOT.png"),
+                       title=f"Stacked residual — OOT only ({line_label})")
+        if A_it.size:
+            m, p16, p84 = _stack(A_it)
+            plot_stack(velocity_grid_kms, m, p16, p84,
+                       os.path.join(fig_dir, "stack_IT.png"),
+                       title=f"Stacked residual — In-transit only ({line_label})")
+
+    # ── STEP 7 — Fit Gaussian to the stacked line ─────────────────────────
     init_sigma_A   = cfg["fit"]["init_sigma_A"]
     init_sigma_kms = C_KMS * init_sigma_A / center_A
     line_fit = fit_gaussian_velocity(velocity_grid_kms, stack_median, init_sigma_kms, center_A=center_A)
 
     plot_stack(velocity_grid_kms, stack_median, stack_p16, stack_p84,
-               os.path.join(fig_dir, cfg["figures"]["stack_png"]))
-    write_table71(
-        os.path.join(tab_dir, cfg["tables"]["table71_csv"]),
-        {
-            "line": "Na I D2",
-            "depth_percent": line_fit.depth * 100.0,
-            "ew_mA": line_fit.ew_A * 1e3,
-            "v0_kms": line_fit.v0_kms,
-            "sigma_kms": line_fit.sigma_kms,
-            "N_in": int(np.sum(in_transit)),
-        },
-    )
+               os.path.join(fig_dir, cfg.get("figures", {}).get("stack_png", "stack.png")),
+               title=f"Stacked residual (planet rest) — {line_label}")
 
-    # ──────────────────────────────────────────────────────────────────────
-    # STEP 8 — Null tests (quality control)
-    #
-    # Aim: Stress-test the detection against common failure modes.
-    # Problem: Spurious signals can arise from OOT normalization, rest-frame
-    #          mistakes, or accidental windows; we need to *falsify* them.
-    #
-    # Tests:
-    #   - OOT-only: stack only OOT → should show no in-transit signal.
-    #   - Wrong rest frame: scramble the planet RF → line should wash out.
-    #   - Control window: shift window by +Δλ → should be consistent with 0.
-    #   - Phase shuffle: break phase coherence → signal should vanish.
-    #
-    # Outputs:
-    #   QC figure with the four null profiles.
-    # ──────────────────────────────────────────────────────────────────────
+    write_table71(os.path.join(tab_dir, cfg["tables"]["table71_csv"]),
+                  {"line": line_label,
+                   "depth_percent": line_fit.depth * 100.0,
+                   "ew_mA": line_fit.ew_A * 1e3,
+                   "v0_kms": line_fit.v0_kms,
+                   "sigma_kms": line_fit.sigma_kms,
+                   "N_in": int(np.sum(in_transit))})
+
+    # ── STEP 8 — Null tests ───────────────────────────────────────────────
     rng = np.random.default_rng(42)
     null_oot     = null_oot_only(velocity_grid_kms, residual_profiles_for_stack, in_transit)
     null_wrong   = null_wrong_rest_frame(velocity_grid_kms, residual_profiles_for_stack, phases, eph.Kp_kms)
-    ctrl_off_A   = cfg.get("null_tests", {}).get("control_offset_A", 2.0)  # +Δλ control window
+    ctrl_off_A   = cfg.get("null_tests", {}).get("control_offset_A", 2.0)
     ctrl_off_kms = C_KMS * ctrl_off_A / center_A
     null_ctrl    = null_control_window(velocity_grid_kms, residual_profiles_for_stack, +ctrl_off_kms)
     null_shuffle = null_phase_shuffle(velocity_grid_kms, residual_profiles_for_stack, phases, eph.Kp_kms, rng)
 
     plot_nulls_grid(
         velocity_grid_kms,
-        [("OOT-only", null_oot), ("Wrong rest frame", null_wrong),
-         ("Control +Δλ", null_ctrl), ("Phase shuffle", null_shuffle)],
-        os.path.join(fig_dir, cfg["figures"]["nulls_png"]),
+        [("OOT-only",        null_oot),
+         ("Wrong rest frame", null_wrong),
+         ("Control +Δλ",      null_ctrl),
+         ("Phase shuffle",    null_shuffle)],
+        os.path.join(fig_dir, cfg.get("figures", {}).get("nulls_png", "nulls.png")),
     )
 
-    # ──────────────────────────────────────────────────────────────────────
-    # STEP 9 — Injection–recovery (sensitivity curve)
-    #
-    # Aim: Calibrate how injected line depths translate to recovered amplitudes
-    #      after the *entire* pipeline (stack + fit). This reveals sensitivity
-    #      and potential bias (under/over-recovery).
-    # Problem: Without this, quoted depths can be misleading due to processing.
-    #
-    # Procedure:
-    #   For each injected depth d:
-    #       a) Subtract a small Gaussian kernel from in-transit exposures.
-    #       b) Bootstrap-resample exposures → median stack each time.
-    #       c) Fit Gaussian amplitude within a fixed window.
-    #       d) Normalize recovered amplitude by d → recovery factor.
-    #
-    # Inputs:
-    #   depths_injected : [N_d] dimensionless fractions
-    #   residual_profiles_for_stack : [N_exp, N_v]
-    #   init_sigma_kms, fit_window_kms
-    # Outputs:
-    #   CSV + figure of recovery vs injected depth with (p16, p84) bands.
-    # Notes:
-    #   - yerr must be non-negative for matplotlib; we enforce it via
-    #     make_nonneg_yerr before plotting.
-    # ──────────────────────────────────────────────────────────────────────
-    depths_injected = np.array(
-        cfg.get("injection", {}).get("depths", [5e-4, 1e-3, 1.5e-3, 2e-3, 2.5e-3, 3e-3]),
-        dtype=float
-    )
-    rng_inj = np.random.default_rng(cfg.get("injection", {}).get("rng_seed", 42))
-    fit_window_kms = cfg["fit"].get("window_kms", C_KMS * (2.0 / center_A))  # default ≈ ±2 Å
-
-    # --- Baseline amplitude (no extra injection) ---
-    profiles_arr = np.asarray(residual_profiles_for_stack, float)  # [N_exp, N_v]
-    fit_window_kms = cfg["fit"].get("window_kms", C_KMS * (2.0 / center_A))
-
-    A0_med, A0_lo, A0_hi = _bootstrap_amp(
-        velocity_grid_kms, profiles_arr, fit_window_kms, init_sigma_kms,
-        nboot=int(cfg.get("injection", {}).get("bootstrap_n", 1000)),
-        rng=rng_inj
-    )
-
-    # --- Build injected profiles per depth on the TRIMMED grid ---
-    injected_profile_sets = []
-    for d in depths_injected:
-        inj = inject_into_residuals(
-            residual_profiles_for_stack, velocity_grid_kms, d, init_sigma_kms, in_transit
-        )
-        injected_profile_sets.append(np.asarray(inj, float))
-
-    # --- Recover delta depth (A_inj - A_base) ---
-    rec, rec_lo, rec_hi = [], [], []
-    for d, inj_set in zip(depths_injected, injected_profile_sets):
-        A_med, A_lo, A_hi = _bootstrap_amp(
-            velocity_grid_kms, inj_set, fit_window_kms, init_sigma_kms,
-            nboot=int(cfg.get("injection", {}).get("bootstrap_n", 1000)),
-            rng=rng_inj
-        )
-        # conservative bounds: subtract opposite sides of the intervals
-        R_med = A_med - A0_med
-        R_lo  = A_lo  - A0_hi
-        R_hi  = A_hi  - A0_lo
-
-        # ensure ordering
-        rlo, r, rhi = np.sort([R_lo, R_med, R_hi])
-        rec.append(r); rec_lo.append(rlo); rec_hi.append(rhi)
-
-    rec    = np.asarray(rec, float)       # fraction
-    rec_lo = np.asarray(rec_lo, float)    # fraction
-    rec_hi = np.asarray(rec_hi, float)    # fraction
-
-    # Plot & save (plots.py already formats in %)
-    _ = make_nonneg_yerr(rec, rec_lo, rec_hi)
-    plot_injection_curves(
-        depths_injected, rec, rec_lo, rec_hi,
-        os.path.join(fig_dir, cfg["figures"]["inject_png"])
-    )
-    write_injection_csv(
-        os.path.join(tab_dir, "injection_recovery.csv"),
-        depths_injected, rec, rec_lo, rec_hi
-    )
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Cambia el flujo a espacio λ (y traduce a v para etapas finales).
- Añade QA de marco de λ: frameqa.py + veredicto rápido frameguess.py.
- Nueva API unificada: make_matrix_lambda() (comentada y robusta).
- Detrend aditivo en bandas laterales y aplanado multiplicativo opcional.
- Colormaps coherentes (λ) + stacks OOT/IT + null tests en v.
- YAML limpio con input_frame y Npix.
- Añade scripts utilitarios y .gitignore actualizado.